### PR TITLE
Add update password configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ data/*
 dependency-reduced-pom.xml
 .classpath
 NOTES
+.idea/

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ Parameters:
 | Name | Required | Default | Description |
 | ----- | ----- | ----- | ----- |
 | `email` | Y | | Email address associated with the User to create the magic link for. |
-| `username` | N | | Username of the User to create the magic link for. Ignores email and forces `force_create`, `update_profile`, and `send_email` to `false` if set. |
+| `username` | N | | Username of the User to create the magic link for. Ignores email and forces `force_create`, `update_profile`, `update_password` and `send_email` to `false` if set. |
 | `client_id` | Y | | Client ID the user will be logging in to. |
 | `redirect_uri` | Y | | Redirect URI. Must be valid for the given client. |
 | `expiration_seconds` | N | 86400 (1 day) | Amount of time the magic link is valid. |
 | `force_create` | N | false | Create a user with this email address as username/email if none exists. |
 | `update_profile` | N | false | Add an UPDATE_PROFILE required action if the user was created. |
+| `update_password` | N | false | Add an UPDATE_PASSWORD required action if the user was created. |
 | `send_email` | N | false | Send the magic link email using the built in template. |
 
 Sample request (replace your access token):
@@ -38,7 +39,7 @@ curl --request POST https://keycloak.host/auth/realms/test/magic-link \
  --header "Accept: application/json" \
  --header "Content-Type: application/json" \
  --header "Authorization: Bearer <access_token>" \
- --data '{"email":"foo@foo.com","client_id":"account-console","redirect_uri":"https://keycloak.host/auth/realms/test/account/","expiration_seconds":3600,"force_create":true,"update_profile":true,"send_email":false}'
+ --data '{"email":"foo@foo.com","client_id":"account-console","redirect_uri":"https://keycloak.host/auth/realms/test/account/","expiration_seconds":3600,"force_create":true,"update_profile":true,"update_password":true,"send_email":false}'
 ```
 Sample response:
 ```

--- a/src/main/java/io/phasetwo/keycloak/magic/MagicLink.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/MagicLink.java
@@ -61,8 +61,9 @@ public class MagicLink {
       RealmModel realm,
       String email,
       boolean forceCreate,
-      boolean updateProfile) {
-    return getOrCreate(session, realm, email, forceCreate, updateProfile, null);
+      boolean updateProfile,
+      boolean updatePassword) {
+    return getOrCreate(session, realm, email, forceCreate, updateProfile, updatePassword, null);
   }
 
   public static UserModel getOrCreate(
@@ -71,13 +72,19 @@ public class MagicLink {
       String email,
       boolean forceCreate,
       boolean updateProfile,
+      boolean updatePassword,
       Consumer<UserModel> onNew) {
     UserModel user = KeycloakModelUtils.findUserByNameOrEmail(session, realm, email);
     if (user == null && forceCreate) {
       user = session.users().addUser(realm, email);
       user.setEnabled(true);
       user.setEmail(email);
-      if (updateProfile) user.addRequiredAction(UserModel.RequiredAction.UPDATE_PROFILE);
+      if (updatePassword) {
+        user.addRequiredAction(UserModel.RequiredAction.UPDATE_PASSWORD);
+      }
+      if (updateProfile) {
+        user.addRequiredAction(UserModel.RequiredAction.UPDATE_PROFILE);
+      }
       if (onNew != null) {
         onNew.accept(user);
       }

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/MagicLinkAuthenticator.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/MagicLinkAuthenticator.java
@@ -34,6 +34,7 @@ public class MagicLinkAuthenticator extends UsernamePasswordForm implements Auth
 
   static final String CREATE_NONEXISTENT_USER_CONFIG_PROPERTY = "ext-magic-create-nonexistent-user";
   static final String UPDATE_PROFILE_ACTION_CONFIG_PROPERTY = "ext-magic-update-profile-action";
+  static final String UPDATE_PASSWORD_ACTION_CONFIG_PROPERTY = "ext-magic-update-password-action";
 
   @Override
   public void authenticate(AuthenticationFlowContext context) {
@@ -100,6 +101,7 @@ public class MagicLinkAuthenticator extends UsernamePasswordForm implements Auth
             email,
             isForceCreate(context, false),
             isUpdateProfile(context, false),
+            isUpdatePassword(context, false),
             MagicLink.registerEvent(event));
     // check for no/invalid email address
     if (user == null || trimToNull(user.getEmail()) == null || !isValidEmail(user.getEmail())) {
@@ -131,6 +133,10 @@ public class MagicLinkAuthenticator extends UsernamePasswordForm implements Auth
 
   private boolean isUpdateProfile(AuthenticationFlowContext context, boolean defaultValue) {
     return is(context, UPDATE_PROFILE_ACTION_CONFIG_PROPERTY, defaultValue);
+  }
+
+  private boolean isUpdatePassword(AuthenticationFlowContext context, boolean defaultValue) {
+    return is(context, UPDATE_PASSWORD_ACTION_CONFIG_PROPERTY, defaultValue);
   }
 
   private boolean is(AuthenticationFlowContext context, String propName, boolean defaultValue) {

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/MagicLinkAuthenticatorFactory.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/MagicLinkAuthenticatorFactory.java
@@ -84,7 +84,14 @@ public class MagicLinkAuthenticatorFactory implements AuthenticatorFactory {
     updateProfile.setHelpText("Add an UPDATE_PROFILE required action if the user was created.");
     updateProfile.setDefaultValue(false);
 
-    return Arrays.asList(createUser, updateProfile);
+    ProviderConfigProperty updatePassword = new ProviderConfigProperty();
+    updatePassword.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+    updatePassword.setName(MagicLinkAuthenticator.UPDATE_PASSWORD_ACTION_CONFIG_PROPERTY);
+    updatePassword.setLabel("Update password on create");
+    updatePassword.setHelpText("Add an UPDATE_PASSWORD required action if the user was created.");
+    updatePassword.setDefaultValue(false);
+
+    return Arrays.asList(createUser, updateProfile, updatePassword);
   }
 
   @Override

--- a/src/main/java/io/phasetwo/keycloak/magic/representation/MagicLinkRequest.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/representation/MagicLinkRequest.java
@@ -26,6 +26,9 @@ public class MagicLinkRequest {
   @JsonProperty("update_profile")
   private boolean updateProfile = false;
 
+  @JsonProperty("update_password")
+  private boolean updatePassword = false;
+
   @JsonProperty("send_email")
   private boolean sendEmail = false;
 }

--- a/src/main/java/io/phasetwo/keycloak/magic/resources/MagicLinkResource.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/resources/MagicLinkResource.java
@@ -42,12 +42,14 @@ public class MagicLinkResource extends AbstractAdminResource {
     String emailOrUsername = rep.getEmail();
     boolean forceCreate = rep.isForceCreate();
     boolean updateProfile = rep.isUpdateProfile();
+    boolean updatePassword = rep.isUpdatePassword();
     boolean sendEmail = rep.isSendEmail();
 
     if (rep.getUsername() != null) {
       emailOrUsername = rep.getUsername();
       forceCreate = false;
       updateProfile = false;
+      updatePassword = true;
       sendEmail = false;
     }
 
@@ -58,6 +60,7 @@ public class MagicLinkResource extends AbstractAdminResource {
             emailOrUsername,
             forceCreate,
             updateProfile,
+            updatePassword,
             MagicLink.registerEvent(event));
     if (user == null)
       throw new NotFoundException(


### PR DESCRIPTION
Signed-off-by: Ulrich VACHON <uvachon@gmail.com>

In this mr I added the possibility to set the update password required action. This is useful when we want to use this SPI with the built-in browser authentication and not with a custom workflow.

By the way, when an user wants to register its account after clicking on the email he will be asked to set his password on the start up of registration process.

Regards,