### PR TITLE
Verify user email after successful email otp usage

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/magic/auth/EmailOtpAuthenticator.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/EmailOtpAuthenticator.java
@@ -68,6 +68,7 @@ public class EmailOtpAuthenticator implements Authenticator {
       if (code != null
           && code.equals(context.getAuthenticationSession().getAuthNote(USER_AUTH_NOTE_OTP_CODE))) {
         context.getAuthenticationSession().removeAuthNote(USER_AUTH_NOTE_OTP_CODE);
+        context.getAuthenticationSession().getAuthenticatedUser().setEmailVerified(true);
         context.success();
         return;
       }


### PR DESCRIPTION
> Proposed change for #37.

Because the usage of an emailed OTP code ensures a user has access to their mailbox, their email should be verified in their Keycloak user account.

@xgp A few questions remains:

1. I noticed two methods for retrieving the authenticated user: `context.getAuthenticationSession().getAuthenticatedUser()` and `context.getUser()`. I have used the former because you yourself use `context.getAuthenticationSession()` in your code. Is there anything else to consider here for making a choice?
2. Both methods may give `null` as a response but I believe they will not because the `EmailOTPAuthenticator` will fail earlier if a user can not be found. Is that a correct assumption?