### PR TITLE
Fix issue with Keycloak IDP nonce mismatch

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/magic/auth/token/MagicLinkActionTokenHandler.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/token/MagicLinkActionTokenHandler.java
@@ -86,6 +86,8 @@ public class MagicLinkActionTokenHandler extends AbstractActionTokenHandler<Magi
       }
       if (token.getNonce() != null) {
         authSession.setClientNote(OIDCLoginProtocol.NONCE_PARAM, token.getNonce());
+        authSession.setAuthNote(OIDCLoginProtocol.NONCE_PARAM, token.getNonce());
+        token.setOtherClaims(OIDCLoginProtocol.NONCE_PARAM, token.getNonce());
       }
     }
 


### PR DESCRIPTION
Add the nonce to other claims to resolve the OIDCIdentityProvider issue with nonce mismatch.

https://github.com/keycloak/keycloak/blob/e14b523a8d569db0f7a0997d247cab12ec2e6011/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java#L416

https://github.com/keycloak/keycloak/blob/e14b523a8d569db0f7a0997d247cab12ec2e6011/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java#L941