### PR TITLE
action token is broken when frontendUrl is set

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <main.java.package>io.phasetwo.keycloak.magic</main.java.package>
     <junit.version>4.13.2</junit.version>
-    <keycloak.version>23.0.3</keycloak.version>
+    <keycloak.version>24.0.0</keycloak.version>
     <lombok.version>1.18.30</lombok.version>
     <auto-service.version>1.1.1</auto-service.version>
     <ossrh.url>https://s01.oss.sonatype.org</ossrh.url>

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/token/MagicLinkActionToken.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/token/MagicLinkActionToken.java
@@ -148,6 +148,7 @@ public class MagicLinkActionToken extends DefaultActionToken {
   }
 
   @Override
+  // Hot fix for https://github.com/keycloak/keycloak/issues/27627
   public String serialize(KeycloakSession session, RealmModel realm, UriInfo uri) {
     String stringUri = uri.getAbsolutePath().toString();
     String issuerUri = stringUri.substring(0, stringUri.lastIndexOf('/'));

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/token/MagicLinkActionToken.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/token/MagicLinkActionToken.java
@@ -1,8 +1,17 @@
 package io.phasetwo.keycloak.magic.auth.token;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import org.keycloak.common.util.Time;
+
 import java.util.UUID;
 import org.keycloak.authentication.actiontoken.DefaultActionToken;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.services.Urls;
 
 public class MagicLinkActionToken extends DefaultActionToken {
 
@@ -77,7 +86,8 @@ public class MagicLinkActionToken extends DefaultActionToken {
   }
 
   private MagicLinkActionToken() {
-    // Note that the class must have a private constructor without any arguments. This is necessary
+    // Note that the class must have a private constructor without any arguments.
+    // This is necessary
     // to deserialize the token class from JWT.
   }
 
@@ -135,5 +145,18 @@ public class MagicLinkActionToken extends DefaultActionToken {
 
   public void setNonce(String value) {
     this.nonce = value;
+  }
+
+  @Override
+  public String serialize(KeycloakSession session, RealmModel realm, UriInfo uri) {
+    String stringUri = uri.getAbsolutePath().toString();
+    String issuerUri = stringUri.substring(0, stringUri.lastIndexOf('/'));
+    
+    this.issuedAt(Time.currentTime())
+        .id(getActionVerificationNonce().toString())
+        .issuer(issuerUri)
+        .audience(issuerUri);
+
+    return session.tokens().encode(this);
   }
 }

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/token/MagicLinkContinuationActionToken.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/token/MagicLinkContinuationActionToken.java
@@ -81,6 +81,7 @@ public class MagicLinkContinuationActionToken extends DefaultActionToken {
   }
 
   @Override
+  // Hot fix for https://github.com/keycloak/keycloak/issues/27627
   public String serialize(KeycloakSession session, RealmModel realm, UriInfo uri) {
     String stringUri = uri.getAbsolutePath().toString();
     String issuerUri = stringUri.substring(0, stringUri.lastIndexOf('/'));

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/token/MagicLinkContinuationLinkActionTokenHandler.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/token/MagicLinkContinuationLinkActionTokenHandler.java
@@ -1,7 +1,6 @@
 package io.phasetwo.keycloak.magic.auth.token;
 
 import static io.phasetwo.keycloak.magic.auth.util.MagicLinkConstants.SESSION_CONFIRMED;
-import static org.keycloak.services.util.CookieHelper.getCookie;
 
 import io.phasetwo.keycloak.magic.auth.model.MagicLinkContinuationBean;
 import io.phasetwo.keycloak.magic.auth.util.MagicLinkConstants;
@@ -58,11 +57,7 @@ public class MagicLinkContinuationLinkActionTokenHandler
           rootAuthenticationSession.getAuthenticationSession(client, token.getTabId());
       if (authenticationFlowSession != null) {
         authenticationFlowSession.setAuthNote(SESSION_CONFIRMED, "true");
-
-        Cookie cookie =
-            getCookie(
-                session.getContext().getRequestHeaders().getCookies(),
-                MagicLinkConstants.AUTH_SESSION_ID);
+        Cookie cookie = session.getContext().getRequestHeaders().getCookies().get(MagicLinkConstants.AUTH_SESSION_ID);
 
         boolean sameBrowser = cookie != null && cookie.getValue().equals(token.getSessionId());
         MagicLinkContinuationBean magicLinkContinuationBean =

--- a/src/main/java/io/phasetwo/keycloak/magic/resources/CorsResource.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/resources/CorsResource.java
@@ -6,7 +6,7 @@ import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.http.HttpResponse;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.services.resources.Cors;
+import org.keycloak.services.cors.Cors;
 import org.keycloak.services.resources.admin.AdminAuth;
 
 @JBossLog


### PR DESCRIPTION
I found a bug that make magic links do not behave the same way when you run with --dev or prod.
In dev the issuer will be the request's host header, while on prod it will be --hostname-url. 
Please see commit [6fe08f9](https://github.com/p2-inc/keycloak-magic-link/pull/70/commits/6fe08f9c6ec1d0d2f54b682902ff580643f26f73) for a fix.