### PR TITLE
Add missing strings for magic link continuation form

### DIFF
--- a/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/src/main/resources/theme-resources/messages/messages_de.properties
@@ -21,5 +21,7 @@ multipleSessionsError=Mehrere Anmeldesitzungen im selben Browser geöffnet. Bitt
 # admin text
 ext-magic-form-display-name=Magischer Link
 ext-magic-form-help-text=Melden Sie sich mit einem magischen Link an, der an Ihre E-Mail gesendet wird.
+magic-link-continuation-form-display-name=Magischer Link
+magic-link-continuation-form-help-text=Melden Sie sich mit einem magischen Link an, der an Ihre E-Mail gesendet wird.
 ext-email-otp-display-name=E-Mail OTP
 ext-email-otp-help-text=Melden Sie sich mit einem Einmal-Passwort an, das an Ihre E-Mail gesendet wird.

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -22,5 +22,7 @@ multipleSessionsError=Multiple login sessions opened on same browser. Please clo
 # admin text
 ext-magic-form-display-name=Magic link
 ext-magic-form-help-text=Sign in with a magic link that will be sent to your email.
+magic-link-continuation-form-display-name=Magic link
+magic-link-continuation-form-help-text=Sign in with a magic link that will be sent to your email.
 ext-email-otp-display-name=Email OTP
 ext-email-otp-help-text=Sign in with a one-time-password that will be sent to your email.

--- a/src/main/resources/theme-resources/messages/messages_es.properties
+++ b/src/main/resources/theme-resources/messages/messages_es.properties
@@ -21,5 +21,7 @@ multipleSessionsError=Múltiples sesiones de inicio de sesión abiertas en el mi
 # admin text
 ext-magic-form-display-name=Enlace mágico
 ext-magic-form-help-text=Inicie sesión con un enlace mágico que se enviará a su correo electrónico.
+magic-link-continuation-form-display-name=Enlace mágico
+magic-link-continuation-form-help-text=Inicie sesión con un enlace mágico que se enviará a su correo electrónico.
 ext-email-otp-display-name=OTP por correo electrónico
 ext-email-otp-help-text=Inicie sesión con una contraseña de un solo uso que se enviará a su correo electrónico.

--- a/src/main/resources/theme-resources/messages/messages_fr.properties
+++ b/src/main/resources/theme-resources/messages/messages_fr.properties
@@ -21,5 +21,7 @@ multipleSessionsError=Plusieurs sessions de connexion ouvertes sur le même navi
 # admin text
 ext-magic-form-display-name=Lien magique
 ext-magic-form-help-text=Connectez-vous avec un lien magique qui sera envoyé à votre e-mail.
+magic-link-continuation-form-display-name=Lien magique
+magic-link-continuation-form-help-text=Connectez-vous avec un lien magique qui sera envoyé à votre e-mail.
 ext-email-otp-display-name=OTP par e-mail
 ext-email-otp-help-text=Connectez-vous avec un mot de passe à usage unique qui sera envoyé à votre e-mail.

--- a/src/main/resources/theme-resources/messages/messages_hu.properties
+++ b/src/main/resources/theme-resources/messages/messages_hu.properties
@@ -21,5 +21,7 @@ multipleSessionsError=Több bejelentkezési munkamenet nyitva ugyanazon a böng�
 # admin text
 ext-magic-form-display-name=Varázslink
 ext-magic-form-help-text=Jelentkezzen be egy varázslinkkel, amelyet elküldünk az e-mail címére.
+magic-link-continuation-form-display-name=Varázslink
+magic-link-continuation-form-help-text=Jelentkezzen be egy varázslinkkel, amelyet elküldünk az e-mail címére.
 ext-email-otp-display-name=E-mail OTP
 ext-email-otp-help-text=Jelentkezzen be egy egyszeri jelszóval, amelyet elküldünk az e-mail címére.

--- a/src/main/resources/theme-resources/messages/messages_it.properties
+++ b/src/main/resources/theme-resources/messages/messages_it.properties
@@ -21,5 +21,7 @@ multipleSessionsError=Più sessioni di accesso aperte sullo stesso browser. Per 
 # admin text
 ext-magic-form-display-name=Link magico
 ext-magic-form-help-text=Accedi con un link magico che verrà inviato alla tua email.
+magic-link-continuation-form-display-name=Link magico
+magic-link-continuation-form-help-text=Accedi con un link magico che verrà inviato alla tua email.
 ext-email-otp-display-name=OTP email
 ext-email-otp-help-text=Accedi con una password monouso che verrà inviata alla tua email.

--- a/src/main/resources/theme-resources/messages/messages_ja.properties
+++ b/src/main/resources/theme-resources/messages/messages_ja.properties
@@ -21,5 +21,7 @@ multipleSessionsError=同じブラウザで複数のログインセッション�
 # admin text
 ext-magic-form-display-name=マジックリンク
 ext-magic-form-help-text=メールに送信されるマジックリンクでサインインします。
+magic-link-continuation-form-display-name=マジックリンク
+magic-link-continuation-form-help-text=メールに送信されるマジックリンクでサインインします。
 ext-email-otp-display-name=メール OTP
 ext-email-otp-help-text=メールに送信されるワンタイムパスワードでサインインします。

--- a/src/main/resources/theme-resources/messages/messages_nl.properties
+++ b/src/main/resources/theme-resources/messages/messages_nl.properties
@@ -21,5 +21,7 @@ multipleSessionsError=Meerdere inlogsessies geopend in dezelfde browser. Sluit d
 # admin text
 ext-magic-form-display-name=Magische link
 ext-magic-form-help-text=Meld u aan met een magische link die naar uw e-mail wordt gestuurd.
+magic-link-continuation-form-display-name=Magische link
+magic-link-continuation-form-help-text=Meld u aan met een magische link die naar uw e-mail wordt gestuurd.
 ext-email-otp-display-name=E-mail OTP
 ext-email-otp-help-text=Meld u aan met een eenmalig wachtwoord dat naar uw e-mail wordt gestuurd.

--- a/src/main/resources/theme-resources/messages/messages_pt.properties
+++ b/src/main/resources/theme-resources/messages/messages_pt.properties
@@ -21,5 +21,7 @@ multipleSessionsError=Múltiplas sessões de login abertas no mesmo navegador. P
 # admin text
 ext-magic-form-display-name=Link mágico
 ext-magic-form-help-text=Entre com um link mágico que será enviado para seu e-mail.
+magic-link-continuation-form-display-name=Link mágico
+magic-link-continuation-form-help-text=Entre com um link mágico que será enviado para seu e-mail.
 ext-email-otp-display-name=OTP por e-mail
 ext-email-otp-help-text=Entre com uma senha única que será enviada para seu e-mail.

--- a/src/main/resources/theme-resources/messages/messages_zh.properties
+++ b/src/main/resources/theme-resources/messages/messages_zh.properties
@@ -21,5 +21,7 @@ multipleSessionsError=在同一浏览器中打开了多个登录会话。请关�
 # admin text
 ext-magic-form-display-name=魔术链接
 ext-magic-form-help-text=使用将发送到您的电子邮件的魔术链接登录。
+magic-link-continuation-form-display-name=魔术链接
+magic-link-continuation-form-help-text=使用将发送到您的电子邮件的魔术链接登录。
 ext-email-otp-display-name=电子邮件 OTP
 ext-email-otp-help-text=使用将发送到您的电子邮件的一次性密码登录。


### PR DESCRIPTION
The magic link continuation form step did not have any text under "Try Another Way". This commit adds the missing strings, copying them from the magic-link step.