### PR TITLE
Localize the "Enter access code" string in otp-form.ftl

### DIFF
--- a/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/src/main/resources/theme-resources/messages/messages_de.properties
@@ -17,6 +17,7 @@ magicLinkSuccessfulLogin=Authentifizierungssitzung bestätigt. Bitte kehren Sie 
 magicLinkFailLogin=Authentifizierungssitzung abgelaufen. Bitte schließen Sie diesen Tab und starten Sie den Anmeldevorgang neu.
 loginPage=Anmeldeseite
 multipleSessionsError=Mehrere Anmeldesitzungen im selben Browser geöffnet. Bitte schließen Sie diese und starten Sie die Anmeldung neu.
+enterAccessCode=Enter access code
 
 # admin text
 ext-magic-form-display-name=Magischer Link

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -18,6 +18,7 @@ magicLinkSuccessfulLogin=Authentication session confirmed. Please return to logi
 magicLinkFailLogin=Authentication session expired. Please close this tab and restart the login flow.
 loginPage=Login page
 multipleSessionsError=Multiple login sessions opened on same browser. Please close it and restart login.
+enterAccessCode=Enter access code
 
 # admin text
 ext-magic-form-display-name=Magic link

--- a/src/main/resources/theme-resources/messages/messages_es.properties
+++ b/src/main/resources/theme-resources/messages/messages_es.properties
@@ -17,6 +17,7 @@ magicLinkSuccessfulLogin=Sesión de autenticación confirmada. Por favor, regres
 magicLinkFailLogin=La sesión de autenticación ha expirado. Por favor, cierre esta pestaña y reinicie el flujo de inicio de sesión.
 loginPage=Página de inicio de sesión
 multipleSessionsError=Múltiples sesiones de inicio de sesión abiertas en el mismo navegador. Por favor, ciérrelas y reinicie el inicio de sesión.
+enterAccessCode=Enter access code
 
 # admin text
 ext-magic-form-display-name=Enlace mágico

--- a/src/main/resources/theme-resources/messages/messages_fr.properties
+++ b/src/main/resources/theme-resources/messages/messages_fr.properties
@@ -17,6 +17,7 @@ magicLinkSuccessfulLogin=Session d''authentification confirmée. Veuillez reveni
 magicLinkFailLogin=La session d''authentification a expiré. Veuillez fermer cet onglet et redémarrer le processus de connexion.
 loginPage=Page de connexion
 multipleSessionsError=Plusieurs sessions de connexion ouvertes sur le même navigateur. Veuillez les fermer et redémarrer la connexion.
+enterAccessCode=Enter access code
 
 # admin text
 ext-magic-form-display-name=Lien magique

--- a/src/main/resources/theme-resources/messages/messages_hu.properties
+++ b/src/main/resources/theme-resources/messages/messages_hu.properties
@@ -17,6 +17,7 @@ magicLinkSuccessfulLogin=Azonosítási munkamenet megerősítve. Kérjük, térj
 magicLinkFailLogin=Azonosítási munkamenet lejárt. Kérjük, zárja be ezt a lapot, és indítsa újra a bejelentkezési folyamatot.
 loginPage=Bejelentkezési oldal
 multipleSessionsError=Több bejelentkezési munkamenet nyitva ugyanazon a böngészőn. Kérjük, zárja be, és indítsa újra a bejelentkezést.
+enterAccessCode=Enter access code
 
 # admin text
 ext-magic-form-display-name=Varázslink

--- a/src/main/resources/theme-resources/messages/messages_it.properties
+++ b/src/main/resources/theme-resources/messages/messages_it.properties
@@ -17,6 +17,7 @@ magicLinkSuccessfulLogin=Sessione di autenticazione confermata. Per favore, torn
 magicLinkFailLogin=Sessione di autenticazione scaduta. Per favore, chiudi questa scheda e riavvia il flusso di accesso.
 loginPage=Pagina di accesso
 multipleSessionsError=Più sessioni di accesso aperte sullo stesso browser. Per favore, chiudile e riavvia l'accesso.
+enterAccessCode=Enter access code
 
 # admin text
 ext-magic-form-display-name=Link magico

--- a/src/main/resources/theme-resources/messages/messages_ja.properties
+++ b/src/main/resources/theme-resources/messages/messages_ja.properties
@@ -17,6 +17,7 @@ magicLinkSuccessfulLogin=認証セッションが確認されました。ログ�
 magicLinkFailLogin=認証セッションが期限切れになりました。このタブを閉じて、ログインフローを再起動してください。
 loginPage=ログインページ
 multipleSessionsError=同じブラウザで複数のログインセッションが開かれています。それを閉じて、ログインを再起動してください。
+enterAccessCode=Enter access code
 
 # admin text
 ext-magic-form-display-name=マジックリンク

--- a/src/main/resources/theme-resources/messages/messages_nl.properties
+++ b/src/main/resources/theme-resources/messages/messages_nl.properties
@@ -17,6 +17,7 @@ magicLinkSuccessfulLogin=Authenticatiesessie bevestigd. Ga terug naar het inlogp
 magicLinkFailLogin=Authenticatiesessie verlopen. Sluit dit tabblad en start het inlogproces opnieuw.
 loginPage=Inlogpagina
 multipleSessionsError=Meerdere inlogsessies geopend in dezelfde browser. Sluit deze en start het inlogproces opnieuw.
+enterAccessCode=Enter access code
 
 # admin text
 ext-magic-form-display-name=Magische link

--- a/src/main/resources/theme-resources/messages/messages_pt.properties
+++ b/src/main/resources/theme-resources/messages/messages_pt.properties
@@ -17,6 +17,7 @@ magicLinkSuccessfulLogin=Sessão de autenticação confirmada. Por favor, volte 
 magicLinkFailLogin=A sessão de autenticação expirou. Por favor, feche esta aba e reinicie o fluxo de login.
 loginPage=Página de login
 multipleSessionsError=Múltiplas sessões de login abertas no mesmo navegador. Por favor, feche-as e reinicie o login.
+enterAccessCode=Enter access code
 
 # admin text
 ext-magic-form-display-name=Link mágico

--- a/src/main/resources/theme-resources/messages/messages_ru.properties
+++ b/src/main/resources/theme-resources/messages/messages_ru.properties
@@ -24,6 +24,7 @@ otpBodyHtml=<p>Кто-то запросил одноразовый пароль 
 magicLinkContinuationSubject=Вход в {0}
 magicLinkContinuationBody=Кто-то запросил ссылку для входа в {0}.\n\nНажмите, чтобы войти.\n\n{1}\n\nЕсли вы не запрашивали эту ссылку, проигнорируйте это письмо.
 magicLinkContinuationBodyHtml=<p>Кто-то запросил ссылку для входа в {0}</p><p><a href="{1}">Нажмите, чтобы войти</a>.</p><p>Если вы не запрашивали эту ссылку, проигнорируйте это письмо.</p>
+enterAccessCode=Enter access code
 
 # login
 magicLinkConfirmation=Проверьте свою электронную почту и нажмите на ссылку, чтобы войти!

--- a/src/main/resources/theme-resources/messages/messages_zh.properties
+++ b/src/main/resources/theme-resources/messages/messages_zh.properties
@@ -17,6 +17,7 @@ magicLinkSuccessfulLogin=认证会话已确认。请返回登录页面标签。
 magicLinkFailLogin=认证会话已过期。请关闭此标签并重新启动登录流程。
 loginPage=登录页面
 multipleSessionsError=在同一浏览器中打开了多个登录会话。请关闭它并重新启动登录。
+enterAccessCode=Enter access code
 
 # admin text
 ext-magic-form-display-name=魔术链接

--- a/src/main/resources/theme-resources/templates/otp-form.ftl
+++ b/src/main/resources/theme-resources/templates/otp-form.ftl
@@ -13,7 +13,7 @@
         </a>
       </div>
     <#elseif section = "form">
-      <p>Enter access code</p>
+      <p>${msg("enterAccessCode")}</p>
       <form id="kc-otp-login-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
         <div class="${properties.kcFormGroupClass!}">
           <div class="${properties.kcLabelWrapperClass!}">


### PR DESCRIPTION
otp-form.ftl uses the literal string "Enter access code" which isn't localized and is difficult to customize.  This change updates the otp-form.ftl form and replaces the string "Enter access code" with the variable "enterAccessCode" and sets enterAccessCode to "Enter access code" in every included language file. 

"Enter access code" is not translated and I'm not familiar enough with these languages to translate them, but using the english string in each language is still an improvment because it can easily be customized by Keycloak administrators and is no worse than the current state of using a literal string in the form.

I kept the string "Enter access code" in the messages files to minimize this change, but I'd like to change it to something like "An access code has been emailed to you, please check your email and enter the access code" to make it more clear to end users.