### PR TITLE
brute force protection for Email-OTP

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/magic/auth/EmailOtpAuthenticator.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/EmailOtpAuthenticator.java
@@ -13,6 +13,7 @@ import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.authenticators.util.AuthenticatorUtils;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
@@ -30,10 +31,10 @@ public class EmailOtpAuthenticator implements Authenticator {
   public static final String FORM_PARAM_OTP_CODE = "otp";
 
   public void authenticate(AuthenticationFlowContext context) {
-    challenge(context, null);
+    challenge(context, null, false);
   }
 
-  private void challenge(AuthenticationFlowContext context, FormMessage errorMessage) {
+  private void challenge(AuthenticationFlowContext context, FormMessage errorMessage, boolean triggerBruteForce) {
     var email = MagicLink.getAttemptedUsername(context);
     sendOtp(context, email);
 
@@ -44,11 +45,17 @@ public class EmailOtpAuthenticator implements Authenticator {
 
     Response response = form.createForm("otp-form.ftl");
 
-    if(errorMessage != null) {
+    if (triggerBruteForce) {
       context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, response);
-    } else {
-      context.challenge(response);
+      return;
     }
+
+    if (errorMessage != null) {
+      context.forceChallenge(response);
+      return;
+    }
+
+    context.challenge(response);
   }
 
   private void sendOtp(AuthenticationFlowContext context, String email) {
@@ -58,15 +65,14 @@ public class EmailOtpAuthenticator implements Authenticator {
     }
     String code = String.format("%06d", ThreadLocalRandom.current().nextInt(999999));
     EventBuilder event = context.newEvent();
-    UserModel user =
-        MagicLink.getOrCreate(
-            context.getSession(),
-            context.getRealm(),
-            email,
-            isForceCreate(context, false),
-            false,
-            false,
-            MagicLink.registerEvent(event, EMAIL_OTP));
+    UserModel user = MagicLink.getOrCreate(
+        context.getSession(),
+        context.getRealm(),
+        email,
+        isForceCreate(context, false),
+        false,
+        false,
+        MagicLink.registerEvent(event, EMAIL_OTP));
 
     if (user == null) {
       log.debugf("User with email %s not found.", context.getUser().getEmail());
@@ -84,12 +90,22 @@ public class EmailOtpAuthenticator implements Authenticator {
   public void action(AuthenticationFlowContext context) {
     log.debug("EmailOtpAuthenticator.action");
 
+    UserModel user = context.getUser();
+    String bruteForceError = AuthenticatorUtils.getDisabledByBruteForceEventError(context, user);
+    if (bruteForceError != null) {
+      context.getEvent().user(user);
+      context.getEvent().error(bruteForceError);
+      challenge(context, new FormMessage(disabledByBruteForceError(bruteForceError)), false);
+      return;
+    }
+
     MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
     if (formData.containsKey("resend")) {
       context.getAuthenticationSession().removeAuthNote(USER_AUTH_NOTE_OTP_CODE);
-      challenge(context, null);
+      challenge(context, null, false);
       return;
     }
+
     String code = formData.getFirst(FORM_PARAM_OTP_CODE);
     log.debugf("Got %s for OTP code in form", code);
     try {
@@ -104,9 +120,8 @@ public class EmailOtpAuthenticator implements Authenticator {
       log.warn("Error comparing OTP code to form", e);
     }
 
-    UserModel user = context.getUser();
     context.getEvent().user(user).event(EventType.LOGIN_ERROR).error(Errors.INVALID_CODE);
-    challenge(context, new FormMessage(Messages.INVALID_ACCESS_CODE));
+    challenge(context, new FormMessage(Messages.INVALID_ACCESS_CODE), true);
   }
 
   @Override
@@ -120,10 +135,19 @@ public class EmailOtpAuthenticator implements Authenticator {
   }
 
   @Override
-  public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {}
+  public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+  }
 
   @Override
-  public void close() {}
+  public void close() {
+  }
+
+  protected String disabledByBruteForceError(String error) {
+    if (Errors.USER_TEMPORARILY_DISABLED.equals(error)) {
+      return EmailOtpMessages.ACCOUNT_TEMPORARILY_DISABLED_EMAIL_OTP;
+    }
+    return EmailOtpMessages.ACCOUNT_PERMANENTLY_DISABLED_EMAIL_OTP;
+  }
 
   private boolean isForceCreate(AuthenticationFlowContext context, boolean defaultValue) {
     return is(context, CREATE_NONEXISTENT_USER_CONFIG_PROPERTY, defaultValue);

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/EmailOtpMessages.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/EmailOtpMessages.java
@@ -1,0 +1,6 @@
+package io.phasetwo.keycloak.magic.auth;
+
+public class EmailOtpMessages {
+  public static final String ACCOUNT_TEMPORARILY_DISABLED_EMAIL_OTP = "accountTemporarilyDisabledMessageEmailOtp";
+  public static final String ACCOUNT_PERMANENTLY_DISABLED_EMAIL_OTP = "accountPermanentlyDisabledMessageEmailOtp";
+}

--- a/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/src/main/resources/theme-resources/messages/messages_de.properties
@@ -17,7 +17,9 @@ magicLinkSuccessfulLogin=Authentifizierungssitzung bestätigt. Bitte kehren Sie 
 magicLinkFailLogin=Authentifizierungssitzung abgelaufen. Bitte schließen Sie diesen Tab und starten Sie den Anmeldevorgang neu.
 loginPage=Anmeldeseite
 multipleSessionsError=Mehrere Anmeldesitzungen im selben Browser geöffnet. Bitte schließen Sie diese und starten Sie die Anmeldung neu.
-enterAccessCode=Enter access code
+enterAccessCode=Zugangscode eingeben
+accountTemporarilyDisabledMessageEmailOtp=Ungültiger Access-Code.
+accountPermanentlyDisabledMessageEmailOtp=Ungültiger Access-Code.
 
 # admin text
 ext-magic-form-display-name=Magischer Link

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -19,6 +19,8 @@ magicLinkFailLogin=Authentication session expired. Please close this tab and res
 loginPage=Login page
 multipleSessionsError=Multiple login sessions opened on same browser. Please close it and restart login.
 enterAccessCode=Enter access code
+accountTemporarilyDisabledMessageEmailOtp=Invalid access code.
+accountPermanentlyDisabledMessageEmailOtp=Invalid access code.
 
 # admin text
 ext-magic-form-display-name=Magic link

--- a/src/main/resources/theme-resources/messages/messages_es.properties
+++ b/src/main/resources/theme-resources/messages/messages_es.properties
@@ -18,6 +18,8 @@ magicLinkFailLogin=La sesión de autenticación ha expirado. Por favor, cierre e
 loginPage=Página de inicio de sesión
 multipleSessionsError=Múltiples sesiones de inicio de sesión abiertas en el mismo navegador. Por favor, ciérrelas y reinicie el inicio de sesión.
 enterAccessCode=Enter access code
+accountTemporarilyDisabledMessageEmailOtp=Código de acceso no válido.
+accountPermanentlyDisabledMessageEmailOtp=Código de acceso no válido.
 
 # admin text
 ext-magic-form-display-name=Enlace mágico

--- a/src/main/resources/theme-resources/messages/messages_fr.properties
+++ b/src/main/resources/theme-resources/messages/messages_fr.properties
@@ -18,6 +18,8 @@ magicLinkFailLogin=La session d''authentification a expiré. Veuillez fermer cet
 loginPage=Page de connexion
 multipleSessionsError=Plusieurs sessions de connexion ouvertes sur le même navigateur. Veuillez les fermer et redémarrer la connexion.
 enterAccessCode=Enter access code
+accountTemporarilyDisabledMessageEmailOtp=Code d''accès invalide.
+accountPermanentlyDisabledMessageEmailOtp=Code d''accès invalide.
 
 # admin text
 ext-magic-form-display-name=Lien magique

--- a/src/main/resources/theme-resources/messages/messages_hu.properties
+++ b/src/main/resources/theme-resources/messages/messages_hu.properties
@@ -18,6 +18,8 @@ magicLinkFailLogin=Azonosítási munkamenet lejárt. Kérjük, zárja be ezt a l
 loginPage=Bejelentkezési oldal
 multipleSessionsError=Több bejelentkezési munkamenet nyitva ugyanazon a böngészőn. Kérjük, zárja be, és indítsa újra a bejelentkezést.
 enterAccessCode=Enter access code
+accountTemporarilyDisabledMessageEmailOtp=Érvénytelen hozzáférési kód.
+accountPermanentlyDisabledMessageEmailOtp=Érvénytelen hozzáférési kód.
 
 # admin text
 ext-magic-form-display-name=Varázslink

--- a/src/main/resources/theme-resources/messages/messages_it.properties
+++ b/src/main/resources/theme-resources/messages/messages_it.properties
@@ -18,6 +18,8 @@ magicLinkFailLogin=Sessione di autenticazione scaduta. Per favore, chiudi questa
 loginPage=Pagina di accesso
 multipleSessionsError=Più sessioni di accesso aperte sullo stesso browser. Per favore, chiudile e riavvia l'accesso.
 enterAccessCode=Enter access code
+accountTemporarilyDisabledMessageEmailOtp=Codice di accesso non valido.
+accountPermanentlyDisabledMessageEmailOtp=Codice di accesso non valido.
 
 # admin text
 ext-magic-form-display-name=Link magico

--- a/src/main/resources/theme-resources/messages/messages_ja.properties
+++ b/src/main/resources/theme-resources/messages/messages_ja.properties
@@ -18,6 +18,8 @@ magicLinkFailLogin=認証セッションが期限切れになりました。こ�
 loginPage=ログインページ
 multipleSessionsError=同じブラウザで複数のログインセッションが開かれています。それを閉じて、ログインを再起動してください。
 enterAccessCode=Enter access code
+accountTemporarilyDisabledMessageEmailOtp=無効なアクセスコードです。
+accountPermanentlyDisabledMessageEmailOtp=無効なアクセスコードです。
 
 # admin text
 ext-magic-form-display-name=マジックリンク

--- a/src/main/resources/theme-resources/messages/messages_nl.properties
+++ b/src/main/resources/theme-resources/messages/messages_nl.properties
@@ -18,6 +18,8 @@ magicLinkFailLogin=Authenticatiesessie verlopen. Sluit dit tabblad en start het 
 loginPage=Inlogpagina
 multipleSessionsError=Meerdere inlogsessies geopend in dezelfde browser. Sluit deze en start het inlogproces opnieuw.
 enterAccessCode=Enter access code
+accountTemporarilyDisabledMessageEmailOtp=Ongeldige toegangscode.
+accountPermanentlyDisabledMessageEmailOtp=Ongeldige toegangscode.
 
 # admin text
 ext-magic-form-display-name=Magische link

--- a/src/main/resources/theme-resources/messages/messages_pt.properties
+++ b/src/main/resources/theme-resources/messages/messages_pt.properties
@@ -18,6 +18,8 @@ magicLinkFailLogin=A sessão de autenticação expirou. Por favor, feche esta ab
 loginPage=Página de login
 multipleSessionsError=Múltiplas sessões de login abertas no mesmo navegador. Por favor, feche-as e reinicie o login.
 enterAccessCode=Enter access code
+accountTemporarilyDisabledMessageEmailOtp=Código de acesso inválido.
+accountPermanentlyDisabledMessageEmailOtp=Código de acesso inválido.
 
 # admin text
 ext-magic-form-display-name=Link mágico

--- a/src/main/resources/theme-resources/messages/messages_ru.properties
+++ b/src/main/resources/theme-resources/messages/messages_ru.properties
@@ -25,6 +25,8 @@ magicLinkContinuationSubject=Вход в {0}
 magicLinkContinuationBody=Кто-то запросил ссылку для входа в {0}.\n\nНажмите, чтобы войти.\n\n{1}\n\nЕсли вы не запрашивали эту ссылку, проигнорируйте это письмо.
 magicLinkContinuationBodyHtml=<p>Кто-то запросил ссылку для входа в {0}</p><p><a href="{1}">Нажмите, чтобы войти</a>.</p><p>Если вы не запрашивали эту ссылку, проигнорируйте это письмо.</p>
 enterAccessCode=Enter access code
+accountTemporarilyDisabledMessageEmailOtp=Неверный код доступа.
+accountPermanentlyDisabledMessageEmailOtp=Неверный код доступа.
 
 # login
 magicLinkConfirmation=Проверьте свою электронную почту и нажмите на ссылку, чтобы войти!

--- a/src/main/resources/theme-resources/messages/messages_zh.properties
+++ b/src/main/resources/theme-resources/messages/messages_zh.properties
@@ -18,6 +18,8 @@ magicLinkFailLogin=认证会话已过期。请关闭此标签并重新启动登�
 loginPage=登录页面
 multipleSessionsError=在同一浏览器中打开了多个登录会话。请关闭它并重新启动登录。
 enterAccessCode=Enter access code
+accountTemporarilyDisabledMessageEmailOtp=无效的访问代码
+accountPermanentlyDisabledMessageEmailOtp=无效的访问代码
 
 # admin text
 ext-magic-form-display-name=魔术链接


### PR DESCRIPTION
This PR adds brute force protection for the email-OTP.

The following error messages are used, which, for security reasons, do not inform the user about the (temporary) blocking. 

accountTemporarilyDisabledMessageEmailOtp=Invalid access code.
accountPermanentlyDisabledMessageEmailOtp=Invalid access code.

However, this can be adjusted via localization.
