### PR TITLE
fix: prevent duplicate reload scripts in view-email-continuation.ftl

### DIFF
--- a/src/main/resources/theme-resources/templates/view-email-continuation.ftl
+++ b/src/main/resources/theme-resources/templates/view-email-continuation.ftl
@@ -12,12 +12,12 @@
     </div>
   <#elseif section = "form">
     ${msg("magicLinkContinuationConfirmation")}
+    <script>
+       (function (w, d) {
+          setTimeout(function(){
+             w.location.reload(1);
+          }, 5000);
+       })(window, document);
+    </script>
   </#if>
-  <script>
-     (function (w, d) {
-        setTimeout(function(){
-           w.location.reload(1);
-        }, 5000);
-     })(window, document);
-  </script>
 </@layout.registrationLayout>


### PR DESCRIPTION
## Problem

The `view-email-continuation.ftl` template currently renders **three identical `location.reload()` scripts** on the same page, causing unnecessary overhead and DOM duplication.

<img width="567" height="94" alt="Screenshot 2025-10-23 at 15 43 50" src="https://github.com/user-attachments/assets/b3dadda8-b023-420d-a582-caec4def3bf5" />

### Root Cause

The script block was placed **outside the conditional `<#if section = ...>` blocks** but **inside the macro invocation**. When the parent template calls `<#nested>` multiple times (for "header", "show-username", and "form" sections), the entire content block gets evaluated each time, resulting in:

- Three duplicate `<script>` tags in the rendered HTML
- Three simultaneous 5-second reload timers running in parallel
- Unnecessary script parsing and execution overhead

### Example of Duplicate Scripts in Rendered HTML

```html
<h1 id="kc-page-title">
  <!-- First script rendered during header section -->
  <script>
    (function (w, d) {
      setTimeout(function(){ w.location.reload(1); }, 5000);
    })(window, document);
  </script>
</h1>

<div id="kc-content-wrapper">
  <!-- Second script rendered during form section -->
  <script>
    (function (w, d) {
      setTimeout(function(){ w.location.reload(1); }, 5000);
    })(window, document);
  </script>
</div>

<!-- Third script rendered at the bottom -->
<script>
  (function (w, d) {
    setTimeout(function(){ w.location.reload(1); }, 5000);
  })(window, document);
</script>
```

## Solution

Move the `<script>` block **inside the `<#elseif section = "form">` conditional** to ensure it renders only once in the form section.

### Changes Made

- Moved the reload script from outside the conditionals to inside the `form` section
- Maintains proper indentation and template structure
- Preserves the polling functionality (still reloads every 5 seconds)

## Testing

- Verified the fix locally with Keycloak magic link continuation flow
- Confirmed only **one script tag** appears in the rendered HTML
- Polling still works correctly (page reloads every 5 seconds as intended)
- Authentication is still successful
 
<img width="398" height="89" alt="Screenshot 2025-10-23 at 15 54 27" src="https://github.com/user-attachments/assets/ef3b7943-950a-467b-9c22-84f17386a9df" />

## Impact

- **Performance**: Eliminates two redundant script executions per page load
- **DOM Cleanliness**: Removes duplicate script tags from the HTML
- **Functionality**: No change - polling behavior remains identical