### PR TITLE
feat: Add organization domain gating for magic link authentication

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/magic/auth/MagicLinkAuthenticator.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/MagicLinkAuthenticator.java
@@ -10,6 +10,8 @@ import io.phasetwo.keycloak.magic.MagicLink;
 import io.phasetwo.keycloak.magic.auth.token.MagicLinkActionToken;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import java.net.URI;
 import java.util.OptionalInt;
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -20,7 +22,10 @@ import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
 import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
 
@@ -32,6 +37,14 @@ public class MagicLinkAuthenticator extends UsernamePasswordForm {
 
   static final String ACTION_TOKEN_PERSISTENT_CONFIG_PROPERTY = "ext-magic-allow-token-reuse";
   static final String ACTION_TOKEN_LIFE_SPAN = "ext-magic-token-life-span";
+
+  // Organization domain gating config properties
+  static final String REQUIRE_ORGANIZATION_DOMAIN_CONFIG_PROPERTY =
+      "ext-magic-require-organization-domain";
+  static final String AUTO_ASSIGN_TO_ORGANIZATION_CONFIG_PROPERTY =
+      "ext-magic-auto-assign-to-organization";
+  static final String UNKNOWN_DOMAIN_REDIRECT_ERROR_CONFIG_PROPERTY =
+      "ext-magic-unknown-domain-redirect-error";
 
   @Override
   public void authenticate(AuthenticationFlowContext context) {
@@ -68,9 +81,34 @@ public class MagicLinkAuthenticator extends UsernamePasswordForm {
       context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
       return;
     }
+
+    // Organization domain gating check
+    OrganizationModel matchedOrg = null;
+    if (isRequireOrganizationDomain(context, false)) {
+      String domain = extractDomainFromEmail(email);
+      log.debugf("Organization domain gating enabled, checking domain: %s", domain);
+
+      if (domain != null) {
+        matchedOrg = findOrganizationByDomain(context, domain);
+      }
+
+      if (matchedOrg == null) {
+        log.debugf("No organization found for domain: %s, redirecting with error", domain);
+        redirectWithUnknownDomainError(context, email);
+        return;
+      }
+      log.debugf("Found matching organization: %s for domain: %s", matchedOrg.getName(), domain);
+    }
+
     String clientId = context.getSession().getContext().getClient().getClientId();
 
     EventBuilder event = context.newEvent();
+
+    // Check if user exists before getOrCreate so we know if it's a new user
+    UserModel existingUser =
+        org.keycloak.models.utils.KeycloakModelUtils.findUserByNameOrEmail(
+            context.getSession(), context.getRealm(), email);
+    boolean isNewUser = existingUser == null;
 
     UserModel user =
         MagicLink.getOrCreate(
@@ -97,6 +135,13 @@ public class MagicLinkAuthenticator extends UsernamePasswordForm {
       log.debugf("user attempted to login with username/email: %s", email);
       context.forceChallenge(context.form().createForm("view-email.ftl"));
       return;
+    }
+
+    // Auto-assign newly created user to matched organization
+    if (isNewUser && matchedOrg != null && isAutoAssignToOrganization(context, true)) {
+      log.debugf(
+          "Auto-assigning new user %s to organization %s", user.getEmail(), matchedOrg.getName());
+      assignUserToOrganization(context, user, matchedOrg);
     }
 
     log.debugf("user is %s %s", user.getEmail(), user.isEnabled());
@@ -163,6 +208,144 @@ public class MagicLinkAuthenticator extends UsernamePasswordForm {
     } catch (NumberFormatException e) {
       log.error("Failed to parse lifespan", e);
       return OptionalInt.empty();
+    }
+  }
+
+  // Organization domain gating config helpers
+  private boolean isRequireOrganizationDomain(
+      AuthenticationFlowContext context, boolean defaultValue) {
+    return is(context, REQUIRE_ORGANIZATION_DOMAIN_CONFIG_PROPERTY, defaultValue);
+  }
+
+  private boolean isAutoAssignToOrganization(
+      AuthenticationFlowContext context, boolean defaultValue) {
+    return is(context, AUTO_ASSIGN_TO_ORGANIZATION_CONFIG_PROPERTY, defaultValue);
+  }
+
+  private String getUnknownDomainRedirectError(
+      AuthenticationFlowContext context, String defaultValue) {
+    return get(context, UNKNOWN_DOMAIN_REDIRECT_ERROR_CONFIG_PROPERTY, defaultValue);
+  }
+
+  /**
+   * Extracts the domain portion from an email address.
+   *
+   * @param email the email address
+   * @return the domain portion, or null if invalid
+   */
+  private String extractDomainFromEmail(String email) {
+    if (email == null || !email.contains("@")) {
+      return null;
+    }
+    int atIndex = email.lastIndexOf('@');
+    if (atIndex < 0 || atIndex >= email.length() - 1) {
+      return null;
+    }
+    return email.substring(atIndex + 1).toLowerCase();
+  }
+
+  /**
+   * Finds an organization by email domain using Keycloak's OrganizationProvider.
+   *
+   * @param context the authentication flow context
+   * @param domain the email domain to search for
+   * @return the matching organization, or null if not found
+   */
+  private OrganizationModel findOrganizationByDomain(
+      AuthenticationFlowContext context, String domain) {
+    OrganizationProvider orgProvider = context.getSession().getProvider(OrganizationProvider.class);
+    if (orgProvider == null) {
+      log.warn("OrganizationProvider not available - organizations feature may not be enabled");
+      return null;
+    }
+
+    // Use getByDomainName which handles domain lookup
+    return orgProvider.getByDomainName(domain);
+  }
+
+  /**
+   * Redirects to the client with an error for unknown domain.
+   *
+   * @param context the authentication flow context
+   * @param email the email that was attempted
+   */
+  private void redirectWithUnknownDomainError(AuthenticationFlowContext context, String email) {
+    String redirectUri = context.getAuthenticationSession().getRedirectUri();
+    String state = context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.STATE_PARAM);
+    String errorCode = getUnknownDomainRedirectError(context, "unknown_domain");
+
+    // Log the event
+    context
+        .getEvent()
+        .detail(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, email)
+        .detail("error", errorCode)
+        .error("unknown_organization_domain");
+
+    if (redirectUri != null) {
+      // Build redirect URI with error parameters (OAuth 2.0 error response format)
+      UriBuilder uriBuilder =
+          UriBuilder.fromUri(URI.create(redirectUri))
+              .queryParam("error", errorCode)
+              .queryParam(
+                  "error_description",
+                  "Email domain is not associated with any organization");
+
+      if (state != null) {
+        uriBuilder.queryParam("state", state);
+      }
+
+      URI errorRedirectUri = uriBuilder.build();
+      log.debugf("Redirecting to client with error: %s", errorRedirectUri);
+
+      Response response = Response.status(Response.Status.FOUND)
+          .location(errorRedirectUri)
+          .build();
+      context.failure(AuthenticationFlowError.ACCESS_DENIED, response);
+    } else {
+      // Fallback: show form with error if no redirect URI
+      log.warn("No redirect_uri available for unknown domain error redirect");
+      context.failure(
+          AuthenticationFlowError.ACCESS_DENIED,
+          context
+              .form()
+              .setError("unknownOrganizationDomain")
+              .createErrorPage(Response.Status.FORBIDDEN));
+    }
+  }
+
+  /**
+   * Assigns a user to an organization as a member.
+   *
+   * @param context the authentication flow context
+   * @param user the user to assign
+   * @param organization the target organization
+   */
+  private void assignUserToOrganization(
+      AuthenticationFlowContext context, UserModel user, OrganizationModel organization) {
+    OrganizationProvider orgProvider = context.getSession().getProvider(OrganizationProvider.class);
+    if (orgProvider == null) {
+      log.warn("OrganizationProvider not available - cannot assign user to organization");
+      return;
+    }
+
+    try {
+      // Add user as a member of the organization via the provider
+      boolean added = orgProvider.addMember(organization, user);
+      if (added) {
+        log.infof(
+            "Successfully assigned user %s to organization %s",
+            user.getEmail(), organization.getName());
+      } else {
+        log.debugf(
+            "User %s was already a member of organization %s",
+            user.getEmail(), organization.getName());
+      }
+    } catch (Exception e) {
+      log.errorf(
+          e,
+          "Failed to assign user %s to organization %s",
+          user.getEmail(),
+          organization.getName());
     }
   }
 

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/MagicLinkAuthenticatorFactory.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/MagicLinkAuthenticatorFactory.java
@@ -1,6 +1,9 @@
 package io.phasetwo.keycloak.magic.auth;
 
 import static io.phasetwo.keycloak.magic.MagicLink.CREATE_NONEXISTENT_USER_CONFIG_PROPERTY;
+import static io.phasetwo.keycloak.magic.auth.MagicLinkAuthenticator.AUTO_ASSIGN_TO_ORGANIZATION_CONFIG_PROPERTY;
+import static io.phasetwo.keycloak.magic.auth.MagicLinkAuthenticator.REQUIRE_ORGANIZATION_DOMAIN_CONFIG_PROPERTY;
+import static io.phasetwo.keycloak.magic.auth.MagicLinkAuthenticator.UNKNOWN_DOMAIN_REDIRECT_ERROR_CONFIG_PROPERTY;
 
 import com.google.auto.service.AutoService;
 import io.phasetwo.keycloak.magic.MagicLink;
@@ -107,8 +110,39 @@ public class MagicLinkAuthenticatorFactory implements AuthenticatorFactory {
     actionTokenLifeSpan.setHelpText(
         "Amount of time the magic link is valid, in seconds. If this value is not specific, it will use the default 86400s (1 day)");
 
+    ProviderConfigProperty requireOrgDomain = new ProviderConfigProperty();
+    requireOrgDomain.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+    requireOrgDomain.setName(REQUIRE_ORGANIZATION_DOMAIN_CONFIG_PROPERTY);
+    requireOrgDomain.setLabel("Require organization domain");
+    requireOrgDomain.setHelpText(
+        "When enabled, only create users if the email domain matches a Keycloak Organization's domain. Users with unrecognized domains will be redirected with an error.");
+    requireOrgDomain.setDefaultValue(false);
+
+    ProviderConfigProperty autoAssignOrg = new ProviderConfigProperty();
+    autoAssignOrg.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+    autoAssignOrg.setName(AUTO_ASSIGN_TO_ORGANIZATION_CONFIG_PROPERTY);
+    autoAssignOrg.setLabel("Auto-assign to organization");
+    autoAssignOrg.setHelpText(
+        "When enabled (and domain matches), automatically add newly created users as members of the matching organization.");
+    autoAssignOrg.setDefaultValue(true);
+
+    ProviderConfigProperty unknownDomainError = new ProviderConfigProperty();
+    unknownDomainError.setType(ProviderConfigProperty.STRING_TYPE);
+    unknownDomainError.setName(UNKNOWN_DOMAIN_REDIRECT_ERROR_CONFIG_PROPERTY);
+    unknownDomainError.setLabel("Unknown domain error code");
+    unknownDomainError.setHelpText(
+        "The error parameter value sent to the client redirect_uri when the email domain doesn't match any organization (e.g., 'unknown_domain').");
+    unknownDomainError.setDefaultValue("unknown_domain");
+
     return List.of(
-        createUser, updateProfile, updatePassword, actionTokenPersistent, actionTokenLifeSpan);
+        createUser,
+        updateProfile,
+        updatePassword,
+        actionTokenPersistent,
+        actionTokenLifeSpan,
+        requireOrgDomain,
+        autoAssignOrg,
+        unknownDomainError);
   }
 
   @Override

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -33,3 +33,6 @@ magic-link-continuation-form-display-name=Magic link
 magic-link-continuation-form-help-text=Sign in with a magic link that will be sent to your email.
 ext-email-otp-display-name=Email OTP
 ext-email-otp-help-text=Sign in with a one-time-password that will be sent to your email.
+
+# organization domain gating
+unknownOrganizationDomain=Your email domain is not recognized. Please contact your administrator or sign up for an account.


### PR DESCRIPTION
## Summary

Adds support for restricting magic link authentication to users whose email domains match a Keycloak Organization's configured domain. This enables B2B/multi-tenant scenarios where only recognized organization members should be able to authenticate.

Resolves #159
Related to #127

## New Configuration Options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| Require organization domain | boolean | false | Only allow users with email domains matching a Keycloak Organization |
| Auto-assign to organization | boolean | true | Automatically add newly created users to the matched organization |
| Unknown domain error code | string | `unknown_domain` | OAuth error parameter sent when domain doesn't match |

## Behavior

When "Require organization domain" is enabled:

1. **Domain extraction**: Extracts domain from submitted email address
2. **Organization lookup**: Queries `OrganizationProvider.getByDomainName(domain)`
3. **No match**: Redirects to client `redirect_uri` with OAuth error response:
   ```
   ?error=unknown_domain&error_description=Email+domain+not+associated+with+any+organization&state=...
   ```
4. **Match + new user**: Creates user, optionally auto-assigns to organization via `OrganizationProvider.addMember()`
5. **Match + existing user**: Proceeds with normal magic link flow

## Why Not a Separate ConditionalAuthenticator?

Per #127, a separate authenticator was suggested for domain blocking. However, this feature is tightly coupled to the magic link flow because:

- It needs to happen *after* email submission but *before* user creation
- Auto-assignment requires the matched organization reference during user creation
- The error redirect needs access to the OAuth state/redirect_uri from the auth session

A separate authenticator would require passing state between authenticators or duplicating the email-to-organization lookup.

## Implementation Notes

- Uses native Keycloak Organizations API (`OrganizationProvider`, `OrganizationModel`)
- Requires Keycloak 26.x with Organizations feature enabled
- All existing functionality unchanged when feature is disabled (default)
- Follows existing code patterns in MagicLinkAuthenticator

## Testing

This has been running in production for ~2 weeks without issues.

Manual test scenarios:
- [x] Known domain, existing user → Magic link sent
- [x] Known domain, new user → User created, assigned to org, magic link sent  
- [x] Unknown domain → Redirect with `error=unknown_domain`
- [x] Feature disabled → Original behavior preserved