### PR TITLE
fix: Email OTP extends UsernamePasswordForm to work without prior username identification

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/magic/auth/EmailOtpAuthenticator.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/EmailOtpAuthenticator.java
@@ -3,6 +3,7 @@ package io.phasetwo.keycloak.magic.auth;
 import static io.phasetwo.keycloak.magic.MagicLink.CREATE_NONEXISTENT_USER_CONFIG_PROPERTY;
 import static io.phasetwo.keycloak.magic.MagicLink.EMAIL_OTP;
 import static io.phasetwo.keycloak.magic.auth.util.Authenticators.is;
+import static org.keycloak.services.validation.Validation.FIELD_USERNAME;
 
 import com.google.common.collect.ImmutableList;
 import io.phasetwo.keycloak.magic.MagicLink;
@@ -11,7 +12,8 @@ import jakarta.ws.rs.core.Response;
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
-import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
+import org.keycloak.authentication.authenticators.browser.UsernamePasswordForm;
 import org.keycloak.authentication.authenticators.util.AuthenticatorUtils;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.events.Errors;
@@ -22,21 +24,123 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.FormMessage;
+import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
 
 @JBossLog
-public class EmailOtpAuthenticator implements Authenticator {
+public class EmailOtpAuthenticator extends UsernamePasswordForm {
 
   public static final String USER_AUTH_NOTE_OTP_CODE = "user-auth-note-otp-code";
   public static final String FORM_PARAM_OTP_CODE = "otp";
 
+  @Override
   public void authenticate(AuthenticationFlowContext context) {
-    challenge(context, null, false);
+    log.debug("EmailOtpAuthenticator.authenticate");
+    String attemptedUsername = MagicLink.getAttemptedUsername(context);
+    if (attemptedUsername == null) {
+      // No user identified yet — show the email/username input form
+      super.authenticate(context);
+    } else {
+      log.debugf(
+          "Found attempted username %s from previous authenticator, skipping login form",
+          attemptedUsername);
+      // User already identified — proceed directly to send OTP and show code form
+      sendOtpAndChallenge(context, attemptedUsername, null, false);
+    }
   }
 
-  private void challenge(
-      AuthenticationFlowContext context, FormMessage errorMessage, boolean triggerBruteForce) {
-    var email = MagicLink.getAttemptedUsername(context);
+  @Override
+  public void action(AuthenticationFlowContext context) {
+    log.debug("EmailOtpAuthenticator.action");
+
+    MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
+
+    // If the user submitted a resend request, clear the code and re-send
+    if (formData.containsKey("resend")) {
+      context.getAuthenticationSession().removeAuthNote(USER_AUTH_NOTE_OTP_CODE);
+      String email = MagicLink.getAttemptedUsername(context);
+      if (email == null) {
+        context.getEvent().error(Errors.USER_NOT_FOUND);
+        Response challengeResponse =
+            challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);
+        context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
+        return;
+      }
+      sendOtpAndChallenge(context, email, null, false);
+      return;
+    }
+
+    // If there's already an OTP code in the session, we're on the OTP form — validate it
+    String existingCode = context.getAuthenticationSession().getAuthNote(USER_AUTH_NOTE_OTP_CODE);
+    if (existingCode != null) {
+      validateOtpCode(context, formData);
+      return;
+    }
+
+    // Otherwise, we're on the email input form — extract the email
+    String email = MagicLink.trimToNull(formData.getFirst(AuthenticationManager.FORM_USERNAME));
+    if (email == null) {
+      email = MagicLink.getAttemptedUsername(context);
+    }
+    log.debugf("email in action is %s", email);
+
+    if (email == null) {
+      context.getEvent().error(Errors.USER_NOT_FOUND);
+      Response challengeResponse =
+          challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);
+      context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
+      return;
+    }
+
+    // Look up or create the user
+    EventBuilder event = context.newEvent();
+    UserModel user =
+        MagicLink.getOrCreate(
+            context.getSession(),
+            context.getRealm(),
+            email,
+            isForceCreate(context, false),
+            false,
+            false,
+            MagicLink.registerEvent(event, EMAIL_OTP));
+
+    if (user == null
+        || MagicLink.trimToNull(user.getEmail()) == null
+        || !MagicLink.isValidEmail(user.getEmail())) {
+      context
+          .getEvent()
+          .detail(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, email)
+          .event(EventType.LOGIN_ERROR)
+          .error(Errors.INVALID_EMAIL);
+      context
+          .getAuthenticationSession()
+          .setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, email);
+      log.debugf("user attempted to login with invalid email: %s", email);
+      Response challengeResponse =
+          challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);
+      context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
+      return;
+    }
+
+    // Check if user is enabled before proceeding
+    if (!enabledUser(context, user)) {
+      return;
+    }
+
+    context.setUser(user);
+    context
+        .getAuthenticationSession()
+        .setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, email);
+
+    // Send OTP and show the code entry form
+    sendOtpAndChallenge(context, email, null, false);
+  }
+
+  private void sendOtpAndChallenge(
+      AuthenticationFlowContext context,
+      String email,
+      FormMessage errorMessage,
+      boolean triggerBruteForce) {
     sendOtp(context, email);
 
     LoginFormsProvider form = context.form().setExecution(context.getExecution().getId());
@@ -70,17 +174,20 @@ public class EmailOtpAuthenticator implements Authenticator {
 
     UserModel user = context.getUser();
     if (user == null) {
-      user = MagicLink.getOrCreate(
-        context.getSession(),
-        context.getRealm(),
-        email,
-        isForceCreate(context, false),
-        false,
-        false,
-        MagicLink.registerEvent(event, EMAIL_OTP));
+      user =
+          MagicLink.getOrCreate(
+              context.getSession(),
+              context.getRealm(),
+              email,
+              isForceCreate(context, false),
+              false,
+              false,
+              MagicLink.registerEvent(event, EMAIL_OTP));
 
       if (user == null) {
-        log.debugf("User with email %s not found.", context.getUser().getEmail());
+        log.debugf("User with email %s not found.", email);
+        context.getEvent().event(EventType.LOGIN_ERROR).error(Errors.USER_NOT_FOUND);
+        context.failure(AuthenticationFlowError.INVALID_USER);
         return;
       }
 
@@ -89,27 +196,35 @@ public class EmailOtpAuthenticator implements Authenticator {
 
     boolean sent = MagicLink.sendOtpEmail(context.getSession(), user, code);
     if (sent) {
-      log.debugf("Sent OTP code %s to email %s", code, context.getUser().getEmail());
+      log.debugf("Sent OTP code to email %s", user.getEmail());
       context.getAuthenticationSession().setAuthNote(USER_AUTH_NOTE_OTP_CODE, code);
     }
   }
 
-  public void action(AuthenticationFlowContext context) {
-    log.debug("EmailOtpAuthenticator.action");
-
+  private void validateOtpCode(
+      AuthenticationFlowContext context, MultivaluedMap<String, String> formData) {
     UserModel user = context.getUser();
+    if (user == null) {
+      log.warn("No user found in authentication context while validating OTP code");
+      context.getEvent().event(EventType.LOGIN_ERROR).error(Errors.USER_NOT_FOUND);
+      context.failure(AuthenticationFlowError.INVALID_USER);
+      return;
+    }
+
     String bruteForceError = AuthenticatorUtils.getDisabledByBruteForceEventError(context, user);
     if (bruteForceError != null) {
       context.getEvent().user(user);
       context.getEvent().error(bruteForceError);
-      challenge(context, new FormMessage(disabledByBruteForceError(bruteForceError)), false);
-      return;
-    }
-
-    MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
-    if (formData.containsKey("resend")) {
-      context.getAuthenticationSession().removeAuthNote(USER_AUTH_NOTE_OTP_CODE);
-      challenge(context, null, false);
+      String email = MagicLink.getAttemptedUsername(context);
+      if (email == null) {
+        context.failure(AuthenticationFlowError.INVALID_USER);
+        return;
+      }
+      sendOtpAndChallenge(
+          context,
+          email,
+          new FormMessage(disabledByBruteForceError(bruteForceError)),
+          false);
       return;
     }
 
@@ -117,9 +232,10 @@ public class EmailOtpAuthenticator implements Authenticator {
     log.debugf("Got %s for OTP code in form", code);
     try {
       if (code != null
-          && code.equals(context.getAuthenticationSession().getAuthNote(USER_AUTH_NOTE_OTP_CODE))) {
+          && code.equals(
+              context.getAuthenticationSession().getAuthNote(USER_AUTH_NOTE_OTP_CODE))) {
         context.getAuthenticationSession().removeAuthNote(USER_AUTH_NOTE_OTP_CODE);
-        context.getAuthenticationSession().getAuthenticatedUser().setEmailVerified(true);
+        user.setEmailVerified(true);
         context.success();
         return;
       }
@@ -128,24 +244,47 @@ public class EmailOtpAuthenticator implements Authenticator {
     }
 
     context.getEvent().user(user).event(EventType.LOGIN_ERROR).error(Errors.INVALID_CODE);
-    challenge(context, new FormMessage(Messages.INVALID_ACCESS_CODE), true);
+    String email = MagicLink.getAttemptedUsername(context);
+    if (email == null) {
+      context.failure(AuthenticationFlowError.INVALID_USER);
+      return;
+    }
+    sendOtpAndChallenge(
+        context,
+        email,
+        new FormMessage(Messages.INVALID_ACCESS_CODE),
+        true);
   }
 
   @Override
-  public boolean requiresUser() {
-    return false;
+  protected boolean validateForm(
+      AuthenticationFlowContext context, MultivaluedMap<String, String> formData) {
+    log.debug("validateForm");
+    return validateUser(context, formData);
   }
 
   @Override
-  public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
-    return true;
+  protected Response challenge(
+      AuthenticationFlowContext context, MultivaluedMap<String, String> formData) {
+    log.debug("challenge");
+    LoginFormsProvider forms = context.form();
+    if (!formData.isEmpty()) forms.setFormData(formData);
+    return forms.createLoginUsername();
   }
 
   @Override
-  public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {}
+  protected Response createLoginForm(LoginFormsProvider form) {
+    log.debug("createLoginForm");
+    return form.createLoginUsername();
+  }
 
   @Override
-  public void close() {}
+  protected String getDefaultChallengeMessage(AuthenticationFlowContext context) {
+    log.debug("getDefaultChallengeMessage");
+    return context.getRealm().isLoginWithEmailAllowed()
+        ? Messages.INVALID_USERNAME_OR_EMAIL
+        : Messages.INVALID_USERNAME;
+  }
 
   protected String disabledByBruteForceError(String error) {
     if (Errors.USER_TEMPORARILY_DISABLED.equals(error)) {


### PR DESCRIPTION
## Summary

Refactors `EmailOtpAuthenticator` to extend `UsernamePasswordForm` (the same pattern used by `MagicLinkAuthenticator`) so that it shows its own email input form when no user has been identified yet. This allows Email OTP to work as an `ALTERNATIVE` authenticator alongside Username+Password and Magic Link in a "Try Another Way" browser flow without requiring a separate username form step first. 

Zipped JAR for testing:
[keycloak-magic-link.zip](https://github.com/user-attachments/files/25587126/keycloak-magic-link.zip)

## Changes

**`EmailOtpAuthenticator.java`** (single file change):

- Changed from `implements Authenticator` → `extends UsernamePasswordForm`
- `authenticate()` now checks `MagicLink.getAttemptedUsername(context)`:
  - If `null` → shows a built-in email input form via `super.authenticate()`
  - If present → sends OTP directly and shows the code entry form
- `action()` now handles two states:
  1. Email form submission → look up/create user → send OTP
  2. OTP code submission → validate code
- Added `validateForm()`, `challenge()`, `createLoginForm()`, `getDefaultChallengeMessage()` overrides (same pattern as `MagicLinkAuthenticator`)
- `sendOtp()` checks `context.getUser()` before calling `MagicLink.getOrCreate()`, avoiding duplicate email lookups when the user is already identified (e.g. 2FA flows)

## Issues fixed

Fixes #115 — Email OTP now works as an `ALTERNATIVE` alongside Magic Link without needing a prior username form  
Fixes #139 — No longer crashes with `ModelDuplicateException` when duplicate emails exist (checks `context.getUser()` first)  
Fixes #157 — "Force create user" now works because the email properly flows through `action()` → `getOrCreate()`

## Flow compatibility

Works in all three common configurations:

| Flow | Behaviour |
|------|-----------|
| **Standalone** (no prior username form) | Shows its own email input → sends OTP → validates code |
| **After Username Form** (2-step) | Picks up `ATTEMPTED_USERNAME` from auth session → sends OTP directly |
| **As 2FA** (after username+password) | Uses `context.getUser()` directly → sends OTP, skips `getOrCreate()` entirely |

## Testing

Tested with Keycloak 26.x in the following browser flow structure:

```
Browser 
Flow (top-level)
├── Cookie                              ALTERNATIVE
├── Identity Provider Redirector        ALTERNATIVE
└── Forms                               ALTERNATIVE
    ├── Auth Methods                    REQUIRED
    │   ├── Username Password Form      ALTERNATIVE
    │   ├── Magic Link                  ALTERNATIVE
    │   └── Email OTP                   ALTERNATIVE  ← this PR
    └── Conditional OTP                 CONDITIONAL
        ├── Condition - User Configured REQUIRED
        └── OTP Form                    REQUIRED
```

"Try Another Way" correctly shows all three options. Selecting Email OTP shows an email input form, sends the 6-digit code, and validates it.

<img width="250"  alt="image" src="https://github.com/user-attachments/assets/4ab9077f-295d-4810-841d-5794f591efea" />
<img width="250"  alt="image" src="https://github.com/user-attachments/assets/ba36fcc6-5fea-43c8-a4ad-4c2aa670a2bf" />
<img width="250"  alt="image" src="https://github.com/user-attachments/assets/026ea331-f5d0-44a1-a368-3c9e3242024f" />

