### PR TITLE
Fix user resolution when username differs from email

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/magic/MagicLink.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/MagicLink.java
@@ -1,6 +1,7 @@
 package io.phasetwo.keycloak.magic;
 
 import static org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME;
+import static org.keycloak.models.utils.KeycloakModelUtils.findUserByNameOrEmail;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -96,12 +97,12 @@ public class MagicLink {
     if (trimToNull(emailOrUsername) == null) {
       return null;
     }
-    UserModel user = null;
-    if (isValidEmail(emailOrUsername)) {
+    UserModel user = findUserByNameOrEmail(session, realm, emailOrUsername);
+    // findUserByNameOrEmail skips the email lookup when loginWithEmailAllowed=false.
+    // Fall back to a direct email lookup so users whose username differs from their
+    // email (e.g. multi-tenant composite usernames) can still receive magic links.
+    if (user == null && isValidEmail(emailOrUsername)) {
       user = session.users().getUserByEmail(realm, emailOrUsername);
-    }
-    if (user == null) {
-      user = session.users().getUserByUsername(realm, emailOrUsername);
     }
     // If the user does not exist, we create it ONLY if forceCreate is true
     if (user == null && forceCreate) {

--- a/src/main/java/io/phasetwo/keycloak/magic/MagicLink.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/MagicLink.java
@@ -98,6 +98,12 @@ public class MagicLink {
       return null;
     }
     UserModel user = findUserByNameOrEmail(session, realm, emailOrUsername);
+    // findUserByNameOrEmail skips the email lookup when loginWithEmailAllowed=false.
+    // Fall back to a direct email lookup so users whose username differs from their
+    // email (e.g. multi-tenant composite usernames) can still receive magic links.
+    if (user == null && isValidEmail(emailOrUsername)) {
+      user = session.users().getUserByEmail(realm, emailOrUsername);
+    }
     // If the user does not exist, we create it ONLY if forceCreate is true
     if (user == null && forceCreate) {
       user = session.users().addUser(realm, emailOrUsername);

--- a/src/main/java/io/phasetwo/keycloak/magic/MagicLink.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/MagicLink.java
@@ -1,7 +1,6 @@
 package io.phasetwo.keycloak.magic;
 
 import static org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME;
-import static org.keycloak.models.utils.KeycloakModelUtils.findUserByNameOrEmail;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -97,12 +96,12 @@ public class MagicLink {
     if (trimToNull(emailOrUsername) == null) {
       return null;
     }
-    UserModel user = findUserByNameOrEmail(session, realm, emailOrUsername);
-    // findUserByNameOrEmail skips the email lookup when loginWithEmailAllowed=false.
-    // Fall back to a direct email lookup so users whose username differs from their
-    // email (e.g. multi-tenant composite usernames) can still receive magic links.
-    if (user == null && isValidEmail(emailOrUsername)) {
+    UserModel user = null;
+    if (isValidEmail(emailOrUsername)) {
       user = session.users().getUserByEmail(realm, emailOrUsername);
+    }
+    if (user == null) {
+      user = session.users().getUserByUsername(realm, emailOrUsername);
     }
     // If the user does not exist, we create it ONLY if forceCreate is true
     if (user == null && forceCreate) {

--- a/src/test/java/io/phasetwo/keycloak/magic/service/MagicLinkUsernameDiffersFromEmailTest.java
+++ b/src/test/java/io/phasetwo/keycloak/magic/service/MagicLinkUsernameDiffersFromEmailTest.java
@@ -1,0 +1,50 @@
+package io.phasetwo.keycloak.magic.service;
+
+import io.phasetwo.keycloak.magic.Helpers;
+import io.phasetwo.keycloak.magic.representation.MagicLinkRequest;
+import io.phasetwo.keycloak.magic.representation.MagicLinkResponse;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.jbosslog.JBossLog;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.testcontainers.Testcontainers;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@JBossLog
+public class MagicLinkUsernameDiffersFromEmailTest extends AbstractMagicLinkTest {
+
+    @Test
+    void testMagicLinkCreation_whenUsernameDiffersFromEmail() throws IOException {
+        // import realm with loginWithEmailAllowed=false
+        Testcontainers.exposeHostPorts(container.getHttpPort());
+        RealmRepresentation testRealm = importRealm("/realms/magic-link-username-differs-from-email.json");
+
+        // create user whose username is NOT their email address
+        UserRepresentation user = Helpers.createUser(keycloak, testRealm.getRealm(), "jsmith", "john@example.com");
+
+        // request magic link by email
+        MagicLinkRequest request = new MagicLinkRequest();
+        request.setEmail("john@example.com");
+        request.setClientId("test-client");
+        request.setRedirectUri("http://localhost");
+        request.setExpirationSeconds(300);
+        request.setForceCreate(false);
+        request.setSendEmail(false);
+
+        var response = postRequest(keycloak, request, testRealm.getRealm());
+        assertThat(response.getStatusCode(), CoreMatchers.is(Response.Status.OK.getStatusCode()));
+
+        MagicLinkResponse magicLinkResponse = Helpers.mapper()
+                .readValue(response.getBody().asString(), MagicLinkResponse.class);
+        assertNotNull(magicLinkResponse);
+        assertTrue(magicLinkResponse.getUserId().equals(user.getId()));
+        assertNotNull(magicLinkResponse.getLink());
+    }
+}

--- a/src/test/resources/realms/magic-link-username-differs-from-email.json
+++ b/src/test/resources/realms/magic-link-username-differs-from-email.json
@@ -1,0 +1,24 @@
+{
+  "realm": "username-test-realm",
+  "displayName": "Username Test Realm",
+  "enabled": true,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": true,
+  "clients": [
+    {
+      "clientId": "test-client",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": ["*"],
+      "webOrigins": ["+"]
+    }
+  ],
+  "smtpServer": {
+    "host": "mailhog",
+    "port": 1025,
+    "from": "noreply@test.io",
+    "auth": "false"
+  }
+}


### PR DESCRIPTION
getOrCreate() delegates to KeycloakModelUtils.findUserByNameOrEmail(), which skips the email lookup when loginWithEmailAllowed=false. This causes magic link creation to fail for any user whose username is not their email address — a valid Keycloak configuration common in multi-tenant setups.

Fix: fall back to getUserByEmail() when findUserByNameOrEmail() returns null and the input is a valid email address.

Adds an integration test that creates a user with username "jsmith" and email "john@example.com" in a realm with loginWithEmailAllowed=false, and verifies that a magic link can be created for that user.