### PR TITLE
fix(javadoc): fix out-of-sequence heading errors introduced by LoginToken PR

### DIFF
--- a/.github/workflows/javadoc-verification.yml
+++ b/.github/workflows/javadoc-verification.yml
@@ -1,0 +1,18 @@
+name: Verify that the Javadoc is valid on PRs
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Build Project with Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Java 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Build with Maven and run Cypress Integration Tests
+        run: mvn --batch-mode javadoc:javadoc

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,14 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.12.0</version>
+        <configuration>
+          <source>${java.version}</source>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/LoginTokenFormAuthenticator.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/LoginTokenFormAuthenticator.java
@@ -16,7 +16,7 @@ import org.keycloak.models.UserModel;
  * if absent. On validation failure the form is re-shown with an error message; the flow never falls
  * through to the next alternative silently.
  *
- * <h3>User-switch behaviour</h3>
+ * <h2>User-switch behaviour</h2>
  *
  * When a user-switch is needed (an active session exists for a different user), the confirmation
  * form ({@code login-token-user-switch.ftl}) is always shown regardless of the token's {@code
@@ -25,7 +25,7 @@ import org.keycloak.models.UserModel;
  * fresh OIDC auth URL with {@code login_hint=lt:{tokenId}} so that {@link LoginTokenVerifier} can
  * complete authentication automatically if it is present in the same flow.
  *
- * <h3>Placement</h3>
+ * <h2>Placement</h2>
  *
  * Add as <strong>ALTERNATIVE</strong> or <strong>REQUIRED</strong> in the browser flow. Unlike
  * {@link LoginTokenVerifier}, this authenticator always shows UI — do not place it before Cookie

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/LoginTokenVerifier.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/LoginTokenVerifier.java
@@ -15,7 +15,7 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
  * Authenticator that completes Login Token authentication inside the Keycloak browser flow via
  * {@code login_hint}.
  *
- * <h3>Flow</h3>
+ * <h2>Flow</h2>
  *
  * <ol>
  *   <li>Backend calls {@code POST /realms/{realm}/login-token} to obtain a UUID credential
@@ -29,7 +29,7 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
  *   <li>Subsequent authenticators (e.g. TOTP for LOA=2) run in the same browser session.
  * </ol>
  *
- * <h3>Placement</h3>
+ * <h2>Placement</h2>
  *
  * Add as <strong>ALTERNATIVE</strong> <em>before Cookie</em> in the browser flow so that
  * {@code login_hint} is evaluated before the Cookie authenticator can short-circuit the flow with a


### PR DESCRIPTION
LoginTokenVerifier and LoginTokenFormAuthenticator (added in #182) used \<h3> as the first heading in their class Javadoc comments. Javadoc treats the class name as an implicit \<h1>, so the first explicit heading must be \<h2>. Changed all four occurrences to \<h2\> so that `mvn --batch-mode javadoc:javadoc` passes.

Also adds a maven-javadoc-plugin version pin in pom.xml and a CI workflow (.github/workflows/javadoc-verification.yml, copied from keycloak-orgs) that runs `mvn --batch-mode javadoc:javadoc` on every PR to catch regressions early.

Note: internal issue phasetwo-keycloak#366 tracks unifying these per-repo CI workflows into a shared/common location so that checks implemented in one repo are not silently missing from others.