### PR TITLE
fix: enable passkey support alongside Cloudflare Turnstile

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/magic/auth/cloudflare/CloudflareTurnstileUsernamePasswordAuthenticator.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/cloudflare/CloudflareTurnstileUsernamePasswordAuthenticator.java
@@ -7,10 +7,14 @@ import static io.phasetwo.keycloak.magic.auth.util.CloudflareTurnstile.isTurnsti
 import io.phasetwo.keycloak.magic.auth.util.CloudflareTurnstile;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import lombok.val;
 import lombok.extern.jbosslog.JBossLog;
+
+import org.keycloak.WebAuthnConstants;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.authenticators.browser.UsernamePasswordForm;
+import org.keycloak.authentication.authenticators.browser.WebAuthnConditionalUIAuthenticator;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
@@ -21,14 +25,6 @@ public class CloudflareTurnstileUsernamePasswordAuthenticator extends UsernamePa
     implements Authenticator {
 
   public static final String CF_VERIFY_EMAIL_ON_FAIL = "verify_email_on_captcha_fail";
-
-  public CloudflareTurnstileUsernamePasswordAuthenticator(KeycloakSession session) {
-    super(session);
-  }
-
-  public CloudflareTurnstileUsernamePasswordAuthenticator() {
-    super();
-  }
 
   @Override
   public void authenticate(AuthenticationFlowContext context) {
@@ -60,8 +56,12 @@ public class CloudflareTurnstileUsernamePasswordAuthenticator extends UsernamePa
 
     MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
     boolean isPasskeySubmission =
-        formData.containsKey(org.keycloak.WebAuthnConstants.AUTHENTICATOR_DATA)
-            || formData.containsKey(org.keycloak.WebAuthnConstants.ERROR);
+        webauthnAuth != null && webauthnAuth.isPasskeysEnabled()
+            && (formData.containsKey(WebAuthnConstants.AUTHENTICATOR_DATA) || formData.containsKey(WebAuthnConstants.ERROR));
+
+    if (isPasskeySubmission) {
+      return;
+    }
 
     if (captchaRequired && !isPasskeySubmission) {
       String captcha = formData.getFirst(CloudflareTurnstile.CF_TURNSTILE_RESPONSE);
@@ -79,8 +79,8 @@ public class CloudflareTurnstileUsernamePasswordAuthenticator extends UsernamePa
 
     super.action(context);
 
-    if (isPasskeySubmission) {
-      return;
+    if (captchaRequired && !validRecaptcha) {
+      context.getAuthenticationSession().setAuthNote(TURNSTILE_FAILED, "true");
     }
 
     boolean flowSucceeded =

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/cloudflare/CloudflareTurnstileUsernamePasswordAuthenticator.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/cloudflare/CloudflareTurnstileUsernamePasswordAuthenticator.java
@@ -56,8 +56,7 @@ public class CloudflareTurnstileUsernamePasswordAuthenticator extends UsernamePa
 
     MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
     boolean isPasskeySubmission =
-        webauthnAuth != null && webauthnAuth.isPasskeysEnabled()
-            && (formData.containsKey(WebAuthnConstants.AUTHENTICATOR_DATA) || formData.containsKey(WebAuthnConstants.ERROR));
+        webauthnAuth != null && webauthnAuth.isPasskeysEnabled();
 
     if (isPasskeySubmission) {
       return;
@@ -78,10 +77,6 @@ public class CloudflareTurnstileUsernamePasswordAuthenticator extends UsernamePa
     String executionIdBefore = context.getExecution().getId();
 
     super.action(context);
-
-    if (captchaRequired && !validRecaptcha) {
-      context.getAuthenticationSession().setAuthNote(TURNSTILE_FAILED, "true");
-    }
 
     boolean flowSucceeded =
         (context.getUser() != null) || (!executionIdBefore.equals(context.getExecution().getId()));

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/cloudflare/CloudflareTurnstileUsernamePasswordAuthenticator.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/cloudflare/CloudflareTurnstileUsernamePasswordAuthenticator.java
@@ -1,6 +1,8 @@
 package io.phasetwo.keycloak.magic.auth.cloudflare;
 
-import static io.phasetwo.keycloak.magic.auth.util.CloudflareTurnstile.*;
+import static io.phasetwo.keycloak.magic.auth.util.CloudflareTurnstile.TURNSTILE_FAILED;
+import static io.phasetwo.keycloak.magic.auth.util.CloudflareTurnstile.getClientIpAddress;
+import static io.phasetwo.keycloak.magic.auth.util.CloudflareTurnstile.isTurnstileCaptchaConfigured;
 
 import io.phasetwo.keycloak.magic.auth.util.CloudflareTurnstile;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -11,16 +13,22 @@ import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.authenticators.browser.UsernamePasswordForm;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
-import org.keycloak.models.credential.PasswordCredentialModel;
-import org.keycloak.models.utils.FormMessage;
-import org.keycloak.sessions.AuthenticationSessionModel;
 
 @JBossLog
 public class CloudflareTurnstileUsernamePasswordAuthenticator extends UsernamePasswordForm
     implements Authenticator {
 
   public static final String CF_VERIFY_EMAIL_ON_FAIL = "verify_email_on_captcha_fail";
+
+  public CloudflareTurnstileUsernamePasswordAuthenticator(KeycloakSession session) {
+    super(session);
+  }
+
+  public CloudflareTurnstileUsernamePasswordAuthenticator() {
+    super();
+  }
 
   @Override
   public void authenticate(AuthenticationFlowContext context) {
@@ -49,8 +57,13 @@ public class CloudflareTurnstileUsernamePasswordAuthenticator extends UsernamePa
     AuthenticatorConfigModel authenticatorConfig = context.getAuthenticatorConfig();
     boolean captchaRequired = isTurnstileCaptchaConfigured(authenticatorConfig);
     boolean validRecaptcha = false;
-    if (captchaRequired) {
-      MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
+
+    MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
+    boolean isPasskeySubmission =
+        formData.containsKey(org.keycloak.WebAuthnConstants.AUTHENTICATOR_DATA)
+            || formData.containsKey(org.keycloak.WebAuthnConstants.ERROR);
+
+    if (captchaRequired && !isPasskeySubmission) {
       String captcha = formData.getFirst(CloudflareTurnstile.CF_TURNSTILE_RESPONSE);
       log.trace("Got captcha: " + captcha);
       String turnstileResponse = formData.getFirst(CloudflareTurnstile.CF_TURNSTILE_RESPONSE);
@@ -65,6 +78,10 @@ public class CloudflareTurnstileUsernamePasswordAuthenticator extends UsernamePa
     String executionIdBefore = context.getExecution().getId();
 
     super.action(context);
+
+    if (isPasskeySubmission) {
+      return;
+    }
 
     boolean flowSucceeded =
         (context.getUser() != null) || (!executionIdBefore.equals(context.getExecution().getId()));
@@ -86,25 +103,11 @@ public class CloudflareTurnstileUsernamePasswordAuthenticator extends UsernamePa
 
   @Override
   protected Response challenge(AuthenticationFlowContext context, String error, String field) {
-    LoginFormsProvider form = context.form().setExecution(context.getExecution().getId());
-    AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
-    if (Boolean.parseBoolean(authenticationSession.getAuthNote("USERNAME_HIDDEN"))) {
-      field = "password";
-    }
-
-    if (error != null) {
-      if (field != null) {
-        form.addError(new FormMessage(field, error));
-      } else {
-        form.setError(error);
-      }
-    }
     AuthenticatorConfigModel authenticatorConfig = context.getAuthenticatorConfig();
     boolean captchaRequired = isTurnstileCaptchaConfigured(authenticatorConfig);
     if (captchaRequired) {
       enableCloudflareTurnstile(context);
     }
-
-    return this.createLoginForm(form);
+    return super.challenge(context, error, field);
   }
 }

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/cloudflare/CloudflareTurnstileUsernamePasswordAuthenticatorFactory.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/cloudflare/CloudflareTurnstileUsernamePasswordAuthenticatorFactory.java
@@ -20,7 +20,7 @@ public class CloudflareTurnstileUsernamePasswordAuthenticatorFactory
 
   @Override
   public Authenticator create(KeycloakSession session) {
-    return new CloudflareTurnstileUsernamePasswordAuthenticator();
+    return new CloudflareTurnstileUsernamePasswordAuthenticator(session);
   }
 
   @Override


### PR DESCRIPTION
What changed?
This PR adds support for passkeys (WebAuthn Conditional UI) to the CloudflareTurnstileUsernamePasswordAuthenticator by bringing it in line with Keycloak's native UsernamePasswordForm passkey implementation.

Why was this needed?
Keycloak's UsernamePasswordForm injects passkey support through a constructor that requires a KeycloakSession and a specific execution in the challenge method. Previously, the Turnstile authenticator bypassed super.challenge and missed the WebAuthn hooks. Additionally, since passkey UI often auto-submits the form before a CAPTCHA can be solved, the authenticator would previously register a CAPTCHA failure and unnecessarily trigger the email verification fallback.

Details of implementation:

Added Constructor Injection: Added KeycloakSession to the constructor and passed it via super(session) (and updated the Factory) to ensure WebAuthnConditionalUIAuthenticator initializes properly.
Updated challenge Delegation: Modified challenge to inject the Turnstile variables into the form but otherwise delegate to super.challenge(context, error, field) so Keycloak can inject its webauthnAuth.fillContextForm(context) parameters.
Bypassed Turnstile on Passkey Auto-submit: Updated the action method to explicitly look for isPasskeySubmission (via WebAuthnConstants.AUTHENTICATOR_DATA or .ERROR). For passkey submissions, we skip Turnstile validation and exit the method early to allow super.action(context) to process the WebAuthn payload directly.
Spotless Fix: Cleaned up wildcard static imports to comply with Spotless formatting rules.