### PR TITLE
feat: Login Token Direct Grant authenticator

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/magic/auth/LoginTokenDirectGrantAuthenticator.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/LoginTokenDirectGrantAuthenticator.java
@@ -21,7 +21,7 @@ import org.keycloak.provider.ProviderConfigProperty;
  * Direct Grant (Resource Owner Password Credentials) authenticator that authenticates a request
  * using a Login Token reference, with no browser interaction.
  *
- * <h3>Flow</h3>
+ * <h2>Flow</h2>
  *
  * <ol>
  *   <li>Backend calls {@code POST /realms/{realm}/login-token} to obtain a UUID credential
@@ -36,7 +36,7 @@ import org.keycloak.provider.ProviderConfigProperty;
  *       and completes the grant — Keycloak issues the tokens directly.
  * </ol>
  *
- * <h3>Placement</h3>
+ * <h2>Placement</h2>
  *
  * Add as <strong>REQUIRED</strong> in the realm's Direct Grant flow. Unlike the browser-flow {@link
  * LoginTokenVerifier}, this authenticator never reads the OIDC {@code login_hint} client note (the

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/LoginTokenDirectGrantAuthenticator.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/LoginTokenDirectGrantAuthenticator.java
@@ -1,0 +1,152 @@
+package io.phasetwo.keycloak.magic.auth;
+
+import static io.phasetwo.keycloak.magic.auth.LoginTokenHelper.DG_USER_DISABLED;
+import static io.phasetwo.keycloak.magic.auth.LoginTokenHelper.RESUME_PREFIX;
+
+import com.google.auto.service.AutoService;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import lombok.extern.jbosslog.JBossLog;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.authentication.authenticators.directgrant.AbstractDirectGrantAuthenticator;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.provider.ProviderConfigProperty;
+
+/**
+ * Direct Grant (Resource Owner Password Credentials) authenticator that authenticates a request
+ * using a Login Token reference, with no browser interaction.
+ *
+ * <h3>Flow</h3>
+ *
+ * <ol>
+ *   <li>Backend calls {@code POST /realms/{realm}/login-token} to obtain a UUID credential
+ *       reference ({@code lt:{uuid}}) stored in {@link
+ *       org.keycloak.models.SingleUseObjectProvider}.
+ *   <li>The caller sends a token request to {@code POST
+ *       /realms/{realm}/protocol/openid-connect/token} with {@code grant_type=password} and the
+ *       login token as the {@code login_token} form parameter (either {@code lt:{uuid}} or the bare
+ *       {@code uuid}). No {@code username} / {@code password} is required.
+ *   <li>This authenticator looks up and validates the token (expiry, client, user) via {@link
+ *       LoginTokenHelper#verifyDirectGrant}, enforces single-use, sets the user and optional LOA,
+ *       and completes the grant — Keycloak issues the tokens directly.
+ * </ol>
+ *
+ * <h3>Placement</h3>
+ *
+ * Add as <strong>REQUIRED</strong> in the realm's Direct Grant flow. Unlike the browser-flow {@link
+ * LoginTokenVerifier}, this authenticator never reads the OIDC {@code login_hint} client note (the
+ * token endpoint is not reached through the authorization endpoint, so that note is never set) and
+ * never performs a cookie user-switch or renders a form/redirect. On any failure it returns a
+ * standard OAuth2 error response instead of throwing, so the caller receives a clean {@code 401
+ * invalid_grant} rather than a server error.
+ */
+@JBossLog
+@AutoService(AuthenticatorFactory.class)
+public class LoginTokenDirectGrantAuthenticator extends AbstractDirectGrantAuthenticator {
+
+  public static final String PROVIDER_ID = "direct-grant-login-token";
+
+  /** Form parameter carrying the login token reference ({@code lt:{uuid}} or the bare uuid). */
+  public static final String PARAM_LOGIN_TOKEN = "login_token";
+
+  @Override
+  public void authenticate(AuthenticationFlowContext context) {
+    String raw = context.getHttpRequest().getDecodedFormParameters().getFirst(PARAM_LOGIN_TOKEN);
+    if (raw == null || raw.isBlank()) {
+      log.debugf("[LT] (direct grant) missing '%s' form parameter", PARAM_LOGIN_TOKEN);
+      context.failure(
+          AuthenticationFlowError.INVALID_CREDENTIALS,
+          errorResponse(
+              Response.Status.UNAUTHORIZED.getStatusCode(),
+              "invalid_request",
+              "Missing '" + PARAM_LOGIN_TOKEN + "' parameter"));
+      return;
+    }
+
+    String tokenId = raw.startsWith(RESUME_PREFIX) ? raw.substring(RESUME_PREFIX.length()) : raw;
+
+    String error = LoginTokenHelper.verifyDirectGrant(context, tokenId);
+    if (error == null) {
+      // verifyDirectGrant already called context.success()
+      return;
+    }
+
+    if (DG_USER_DISABLED.equals(error)) {
+      context.failure(
+          AuthenticationFlowError.USER_DISABLED,
+          errorResponse(
+              Response.Status.BAD_REQUEST.getStatusCode(), "invalid_grant", "Account disabled"));
+    } else {
+      context.failure(
+          AuthenticationFlowError.INVALID_CREDENTIALS,
+          errorResponse(
+              Response.Status.UNAUTHORIZED.getStatusCode(),
+              "invalid_grant",
+              "Invalid or expired login token"));
+    }
+  }
+
+  @Override
+  public boolean requiresUser() {
+    return false;
+  }
+
+  @Override
+  public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+    return true;
+  }
+
+  @Override
+  public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {}
+
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
+
+  @Override
+  public String getDisplayType() {
+    return "Login Token Direct Grant";
+  }
+
+  @Override
+  public String getHelpText() {
+    return "Authenticates a Resource Owner Password Credentials (direct grant) request using a"
+        + " Login Token reference passed as the '"
+        + PARAM_LOGIN_TOKEN
+        + "' form parameter (lt:{uuid} or bare uuid). No browser interaction.";
+  }
+
+  @Override
+  public String getReferenceCategory() {
+    return "magic-link";
+  }
+
+  @Override
+  public boolean isConfigurable() {
+    return false;
+  }
+
+  @Override
+  public boolean isUserSetupAllowed() {
+    return false;
+  }
+
+  @Override
+  public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+    return new AuthenticationExecutionModel.Requirement[] {
+      AuthenticationExecutionModel.Requirement.REQUIRED,
+      AuthenticationExecutionModel.Requirement.DISABLED,
+    };
+  }
+
+  @Override
+  public List<ProviderConfigProperty> getConfigProperties() {
+    return List.of();
+  }
+}

--- a/src/main/java/io/phasetwo/keycloak/magic/auth/LoginTokenHelper.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/auth/LoginTokenHelper.java
@@ -1,6 +1,13 @@
 package io.phasetwo.keycloak.magic.auth;
 
-import static io.phasetwo.keycloak.magic.auth.token.LoginToken.*;
+import static io.phasetwo.keycloak.magic.auth.token.LoginToken.KEY_CLIENT_ID;
+import static io.phasetwo.keycloak.magic.auth.token.LoginToken.KEY_CONFIRM_USER_SWITCH;
+import static io.phasetwo.keycloak.magic.auth.token.LoginToken.KEY_EXPIRY;
+import static io.phasetwo.keycloak.magic.auth.token.LoginToken.KEY_LOA;
+import static io.phasetwo.keycloak.magic.auth.token.LoginToken.KEY_REMEMBER_ME;
+import static io.phasetwo.keycloak.magic.auth.token.LoginToken.KEY_REUSABLE;
+import static io.phasetwo.keycloak.magic.auth.token.LoginToken.KEY_SEV;
+import static io.phasetwo.keycloak.magic.auth.token.LoginToken.KEY_USER_ID;
 
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -34,43 +41,144 @@ import org.keycloak.services.managers.AuthenticationManager;
  * <ul>
  *   <li>{@link #handleTokenId} — full token verification pipeline; callers supply lambdas for the
  *       two points that differ between the two authenticators.
- *   <li>{@link #handleUserSwitchAction} — logout / cancel dispatch for the user-switch
- *       confirmation form.
+ *   <li>{@link #handleUserSwitchAction} — logout / cancel dispatch for the user-switch confirmation
+ *       form.
  *   <li>{@link #redirectAfterLogout} — cookie expiry + fresh OIDC auth redirect.
- *   <li>{@link #completeAuth} — single-use enforcement, user/LOA/remember-me setup,
- *       {@code context.success()}.
+ *   <li>{@link #completeAuth} — single-use enforcement, user/LOA/remember-me setup, {@code
+ *       context.success()}.
  * </ul>
  */
 @JBossLog
 class LoginTokenHelper {
 
   // Infinispan key prefixes
-  static final String RESUME_PREFIX   = "lt:";
+  static final String RESUME_PREFIX = "lt:";
   static final String DATA_KEY_PREFIX = "lt:data:";
   static final String USED_KEY_PREFIX = "lt:used:";
 
+  // Direct-grant verification result codes (see verifyDirectGrant)
+  /** Token missing, expired, client-mismatched, or already redeemed. */
+  static final String DG_INVALID_TOKEN = "invalid_token";
+
+  /** Resolved user does not exist or is disabled. */
+  static final String DG_USER_DISABLED = "user_disabled";
+
   // Auth-session notes
   /** tokenId pending user-switch confirmation. */
-  static final String NOTE_PENDING_TOKEN    = "lt_pending_token";
+  static final String NOTE_PENDING_TOKEN = "lt_pending_token";
+
   /** Display name of the currently logged-in (cookie) user. */
   static final String NOTE_CURRENT_USERNAME = "lt_current_username";
+
   /** Display name of the login token target user. */
-  static final String NOTE_TARGET_USERNAME  = "lt_target_username";
+  static final String NOTE_TARGET_USERNAME = "lt_target_username";
 
   private LoginTokenHelper() {}
+
+  // -------------------------------------------------------------------------
+  // Shared lookup + validation
+  // -------------------------------------------------------------------------
+
+  /** Outcome of {@link #lookupAndValidate}. */
+  enum LookupStatus {
+    OK,
+    /** Token not found, expired, malformed, or client-mismatched. */
+    INVALID,
+    /** Token resolved to a user that does not exist or is disabled. */
+    USER_DISABLED
+  }
+
+  /** Result of {@link #lookupAndValidate}; the data fields are only set when {@code status == OK}. */
+  static final class ResolvedToken {
+    final LookupStatus status;
+    final Map<String, String> notes;
+    final String expiryStr;
+    final UserModel user;
+
+    private ResolvedToken(
+        LookupStatus status, Map<String, String> notes, String expiryStr, UserModel user) {
+      this.status = status;
+      this.notes = notes;
+      this.expiryStr = expiryStr;
+      this.user = user;
+    }
+
+    static ResolvedToken invalid() {
+      return new ResolvedToken(LookupStatus.INVALID, null, null, null);
+    }
+
+    static ResolvedToken userDisabled() {
+      return new ResolvedToken(LookupStatus.USER_DISABLED, null, null, null);
+    }
+
+    static ResolvedToken ok(Map<String, String> notes, String expiryStr, UserModel user) {
+      return new ResolvedToken(LookupStatus.OK, notes, expiryStr, user);
+    }
+  }
+
+  /**
+   * Shared token resolution used by both the browser ({@link #handleTokenId}) and direct-grant
+   * ({@link #verifyDirectGrant}) flows: Infinispan lookup → expiry → client → user resolution. Does
+   * not perform the cookie user-switch check or the single-use reservation, and never touches the
+   * flow context — each caller decides how to signal the outcome.
+   *
+   * <p>A present-but-non-numeric {@code expiry} note is treated as {@link LookupStatus#INVALID}
+   * rather than propagating a {@link NumberFormatException}.
+   */
+  static ResolvedToken lookupAndValidate(AuthenticationFlowContext context, String tokenId) {
+    SingleUseObjectProvider singleUse =
+        context.getSession().getProvider(SingleUseObjectProvider.class);
+
+    Map<String, String> notes = singleUse.get(DATA_KEY_PREFIX + tokenId);
+    if (notes == null) {
+      log.warnf("[LT] credential not found or expired for tokenId='%s'", tokenId);
+      return ResolvedToken.invalid();
+    }
+
+    String expiryStr = notes.get(KEY_EXPIRY);
+    if (expiryStr != null) {
+      long expiry;
+      try {
+        expiry = Long.parseLong(expiryStr);
+      } catch (NumberFormatException e) {
+        log.warnf("[LT] malformed expiry '%s' for tokenId='%s'", expiryStr, tokenId);
+        return ResolvedToken.invalid();
+      }
+      if (System.currentTimeMillis() / 1000L > expiry) {
+        log.warnf("[LT] credential expired for tokenId='%s'", tokenId);
+        return ResolvedToken.invalid();
+      }
+    }
+
+    String storedClientId = notes.get(KEY_CLIENT_ID);
+    String sessionClientId = context.getAuthenticationSession().getClient().getClientId();
+    if (storedClientId != null && !storedClientId.equals(sessionClientId)) {
+      log.warnf("[LT] client mismatch: stored='%s', flow='%s'", storedClientId, sessionClientId);
+      return ResolvedToken.invalid();
+    }
+
+    String userId = notes.get(KEY_USER_ID);
+    UserModel user = context.getSession().users().getUserById(context.getRealm(), userId);
+    if (user == null || !user.isEnabled()) {
+      log.warnf("[LT] user '%s' not found or disabled", userId);
+      return ResolvedToken.userDisabled();
+    }
+
+    return ResolvedToken.ok(notes, expiryStr, user);
+  }
 
   // -------------------------------------------------------------------------
   // Core verification pipeline
   // -------------------------------------------------------------------------
 
   /**
-   * Full Login Token verification: Infinispan lookup → expiry → client → user → cookie
-   * user-switch check → {@link #completeAuth}.
+   * Full Login Token verification: Infinispan lookup → expiry → client → user → cookie user-switch
+   * check → {@link #completeAuth}.
    *
    * <p>The two parameters capture the only behavioural differences between the two authenticators:
    *
-   * @param onInvalidToken called when the token is not found, expired, or client-mismatched.
-   *     {@link LoginTokenVerifier}: {@code clearLoginHint + context.attempted()}. {@link
+   * @param onInvalidToken called when the token is not found, expired, or client-mismatched. {@link
+   *     LoginTokenVerifier}: {@code clearLoginHint + context.attempted()}. {@link
    *     LoginTokenFormAuthenticator}: re-show form with an error message.
    * @param onAutoLogout called with the {@code tokenId} when a different user is already logged in
    *     AND the token's {@code confirmUserSwitch} flag is {@code false}. Pass {@code null} to
@@ -82,41 +190,21 @@ class LoginTokenHelper {
       Runnable onInvalidToken,
       Consumer<String> onAutoLogout) {
 
-    SingleUseObjectProvider singleUse =
-        context.getSession().getProvider(SingleUseObjectProvider.class);
-
-    Map<String, String> notes = singleUse.get(DATA_KEY_PREFIX + tokenId);
-    if (notes == null) {
-      log.warnf("[LT] credential not found or expired for tokenId='%s'", tokenId);
-      onInvalidToken.run();
-      return;
+    ResolvedToken resolved = lookupAndValidate(context, tokenId);
+    switch (resolved.status) {
+      case INVALID:
+        onInvalidToken.run();
+        return;
+      case USER_DISABLED:
+        context.failure(AuthenticationFlowError.USER_DISABLED);
+        return;
+      default:
+        break;
     }
 
-    // Validate expiry
-    String expiryStr = notes.get(KEY_EXPIRY);
-    if (expiryStr != null && System.currentTimeMillis() / 1000L > Long.parseLong(expiryStr)) {
-      log.warnf("[LT] credential expired for tokenId='%s'", tokenId);
-      onInvalidToken.run();
-      return;
-    }
-
-    // Validate client
-    String storedClientId = notes.get(KEY_CLIENT_ID);
-    String sessionClientId = context.getAuthenticationSession().getClient().getClientId();
-    if (storedClientId != null && !storedClientId.equals(sessionClientId)) {
-      log.warnf("[LT] client mismatch: stored='%s', flow='%s'", storedClientId, sessionClientId);
-      onInvalidToken.run();
-      return;
-    }
-
-    // Resolve target user
-    String userId = notes.get(KEY_USER_ID);
-    UserModel targetUser = context.getSession().users().getUserById(context.getRealm(), userId);
-    if (targetUser == null || !targetUser.isEnabled()) {
-      log.warnf("[LT] user '%s' not found or disabled", userId);
-      context.failure(AuthenticationFlowError.USER_DISABLED);
-      return;
-    }
+    Map<String, String> notes = resolved.notes;
+    String expiryStr = resolved.expiryStr;
+    UserModel targetUser = resolved.user;
 
     // Check for an existing session belonging to a different user.
     AuthenticationManager.AuthResult cookie =
@@ -127,13 +215,14 @@ class LoginTokenHelper {
         && !cookie.getUser().getId().equals(targetUser.getId())) {
 
       String currentDisplay = displayName(cookie.getUser());
-      String targetDisplay  = displayName(targetUser);
+      String targetDisplay = displayName(targetUser);
       log.debugf("[LT] user switch required: '%s' → '%s'", currentDisplay, targetDisplay);
 
       boolean confirmFlag = "true".equalsIgnoreCase(notes.get(KEY_CONFIRM_USER_SWITCH));
       if (onAutoLogout != null && !confirmFlag) {
         // Auto-logout: caller (LoginTokenVerifier) handles the redirect.
-        log.debugf("[LT] auto-logout: signing out '%s' to authenticate '%s'",
+        log.debugf(
+            "[LT] auto-logout: signing out '%s' to authenticate '%s'",
             currentDisplay, targetDisplay);
         onAutoLogout.accept(tokenId);
       } else {
@@ -152,8 +241,8 @@ class LoginTokenHelper {
   // -------------------------------------------------------------------------
 
   /**
-   * Sets auth-session notes and renders {@code login-token-user-switch.ftl} to ask the user
-   * whether they want to sign out of the current session and continue as the target user.
+   * Sets auth-session notes and renders {@code login-token-user-switch.ftl} to ask the user whether
+   * they want to sign out of the current session and continue as the target user.
    */
   static void showUserSwitchForm(
       AuthenticationFlowContext context,
@@ -177,15 +266,13 @@ class LoginTokenHelper {
    * Dispatches the user-switch confirmation form submission: {@code action=logout} delegates to
    * {@code onLogout}; any other value (i.e. "cancel") calls {@link #failWithAccessDenied}.
    *
-   * @param onLogout called with {@code pendingToken} when the user confirms the logout.
-   *     {@link LoginTokenVerifier}: redirects using the original {@code login_hint} from the auth
-   *     session. {@link LoginTokenFormAuthenticator}: redirects using a reconstructed
-   *     {@code login_hint=lt:{tokenId}}.
+   * @param onLogout called with {@code pendingToken} when the user confirms the logout. {@link
+   *     LoginTokenVerifier}: redirects using the original {@code login_hint} from the auth session.
+   *     {@link LoginTokenFormAuthenticator}: redirects using a reconstructed {@code
+   *     login_hint=lt:{tokenId}}.
    */
   static void handleUserSwitchAction(
-      AuthenticationFlowContext context,
-      String pendingToken,
-      Consumer<String> onLogout) {
+      AuthenticationFlowContext context, String pendingToken, Consumer<String> onLogout) {
     String action = context.getHttpRequest().getDecodedFormParameters().getFirst("action");
     if ("logout".equals(action)) {
       onLogout.accept(pendingToken);
@@ -205,19 +292,16 @@ class LoginTokenHelper {
    */
   static void failWithAccessDenied(AuthenticationFlowContext context) {
     String redirectUri = context.getAuthenticationSession().getRedirectUri();
-    String state =
-        context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.STATE_PARAM);
+    String state = context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.STATE_PARAM);
     jakarta.ws.rs.core.UriBuilder errorUri =
         jakarta.ws.rs.core.UriBuilder.fromUri(redirectUri)
             .queryParam("error", "access_denied")
-            .queryParam(
-                "error_description", "User+cancelled+the+login+token+authentication");
+            .queryParam("error_description", "User+cancelled+the+login+token+authentication");
     if (state != null && !state.isBlank()) {
       errorUri.queryParam("state", state);
     }
     context.failure(
-        AuthenticationFlowError.ACCESS_DENIED,
-        Response.seeOther(errorUri.build()).build());
+        AuthenticationFlowError.ACCESS_DENIED, Response.seeOther(errorUri.build()).build());
   }
 
   // -------------------------------------------------------------------------
@@ -229,31 +313,30 @@ class LoginTokenHelper {
    * authorization request.
    *
    * <p>The old user session is intentionally left alive in Infinispan; removing it inside this
-   * request would conflict with Keycloak's session-persistence worker, producing a duplicate-key
-   * DB error. It will expire naturally via its TTL.
+   * request would conflict with Keycloak's session-persistence worker, producing a duplicate-key DB
+   * error. It will expire naturally via its TTL.
    *
-   * @param loginHint the {@code login_hint} value to include in the redirect URL.
-   *     {@link LoginTokenVerifier}: the original {@code login_hint} from the auth session client
-   *     note (already contains {@code lt:{tokenId}}).
-   *     {@link LoginTokenFormAuthenticator}: {@code "lt:" + tokenId} reconstructed from the
-   *     tokenId (the user typed the token manually, so no OIDC login_hint was set).
+   * @param loginHint the {@code login_hint} value to include in the redirect URL. {@link
+   *     LoginTokenVerifier}: the original {@code login_hint} from the auth session client note
+   *     (already contains {@code lt:{tokenId}}). {@link LoginTokenFormAuthenticator}: {@code "lt:"
+   *     + tokenId} reconstructed from the tokenId (the user typed the token manually, so no OIDC
+   *     login_hint was set).
    */
   static void redirectAfterLogout(
       AuthenticationFlowContext context, String tokenId, String loginHint) {
     // Collect all auth-session params before expiring cookies (the auth session object
     // remains valid in-memory for this request even after the cookie is expired).
-    String clientId            = context.getAuthenticationSession().getClient().getClientId();
-    String redirectUri         = context.getAuthenticationSession().getRedirectUri();
-    String scope               =
-        context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.SCOPE_PARAM);
-    String codeChallenge       =
+    String clientId = context.getAuthenticationSession().getClient().getClientId();
+    String redirectUri = context.getAuthenticationSession().getRedirectUri();
+    String scope = context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.SCOPE_PARAM);
+    String codeChallenge =
         context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.CODE_CHALLENGE_PARAM);
     String codeChallengeMethod =
-        context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.CODE_CHALLENGE_METHOD_PARAM);
-    String state               =
-        context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.STATE_PARAM);
-    String nonce               =
-        context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.NONCE_PARAM);
+        context
+            .getAuthenticationSession()
+            .getClientNote(OIDCLoginProtocol.CODE_CHALLENGE_METHOD_PARAM);
+    String state = context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.STATE_PARAM);
+    String nonce = context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.NONCE_PARAM);
 
     // Expire the Keycloak identity cookies (KEYCLOAK_IDENTITY / KEYCLOAK_SESSION) AND the
     // auth-session cookie (AUTH_SESSION_ID). Without expiring AUTH_SESSION_ID, the redirect
@@ -267,14 +350,14 @@ class LoginTokenHelper {
         .expire(org.keycloak.cookie.CookieType.AUTH_SESSION_ID);
 
     jakarta.ws.rs.core.UriBuilder authUri =
-        jakarta.ws.rs.core.UriBuilder
-            .fromUri(context.getSession().getContext().getUri().getBaseUri())
+        jakarta.ws.rs.core.UriBuilder.fromUri(
+                context.getSession().getContext().getUri().getBaseUri())
             .path("realms/{realm}/protocol/openid-connect/auth")
-            .queryParam("client_id",     clientId)
+            .queryParam("client_id", clientId)
             .queryParam("response_type", "code")
-            .queryParam("login_hint",    loginHint)
-            .queryParam("prompt",        "login")
-            .queryParam("redirect_uri",  redirectUri);
+            .queryParam("login_hint", loginHint)
+            .queryParam("prompt", "login")
+            .queryParam("redirect_uri", redirectUri);
     if (scope != null && !scope.isBlank()) {
       authUri.queryParam("scope", scope);
     }
@@ -292,8 +375,7 @@ class LoginTokenHelper {
     }
 
     log.debugf("[LT] cookie expiry + redirect for token '%s'", tokenId);
-    context.challenge(
-        Response.seeOther(authUri.build(context.getRealm().getName())).build());
+    context.challenge(Response.seeOther(authUri.build(context.getRealm().getName())).build());
   }
 
   // -------------------------------------------------------------------------
@@ -306,8 +388,9 @@ class LoginTokenHelper {
    */
   static void clearLoginHint(AuthenticationFlowContext context) {
     context.getAuthenticationSession().removeClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM);
-    context.getAuthenticationSession().removeAuthNote(
-        AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME);
+    context
+        .getAuthenticationSession()
+        .removeAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME);
   }
 
   static String displayName(UserModel user) {
@@ -362,23 +445,55 @@ class LoginTokenHelper {
       String expiryStr,
       UserModel user) {
 
-    // Single-use enforcement
-    boolean isReusable = "true".equalsIgnoreCase(notes.get(KEY_REUSABLE));
-    if (!isReusable) {
-      long remainingTtl =
-          expiryStr != null
-              ? Math.max(1L, Long.parseLong(expiryStr) - (System.currentTimeMillis() / 1000L))
-              : 300L;
-      if (!context
-          .getSession()
-          .getProvider(SingleUseObjectProvider.class)
-          .putIfAbsent(USED_KEY_PREFIX + tokenId, remainingTtl)) {
-        log.warnf("[LT] token already used: '%s'", tokenId);
-        context.failure(AuthenticationFlowError.INVALID_CREDENTIALS);
-        return;
-      }
+    if (!reserveSingleUse(context, tokenId, notes, expiryStr)) {
+      context.failure(AuthenticationFlowError.INVALID_CREDENTIALS);
+      return;
     }
 
+    applyAuthenticatedUser(context, notes, user);
+  }
+
+  /**
+   * Atomically reserves a non-reusable token for single use by recording {@code lt:used:{tokenId}}
+   * in {@link SingleUseObjectProvider}. Reusable tokens always pass.
+   *
+   * <p>This method has no side effect on the flow context — the caller decides how to signal a
+   * duplicate redemption (the browser authenticators fail without a response; the direct-grant
+   * authenticator returns an OAuth error response).
+   *
+   * @return {@code false} if a non-reusable token was already redeemed, {@code true} otherwise.
+   */
+  static boolean reserveSingleUse(
+      AuthenticationFlowContext context,
+      String tokenId,
+      Map<String, String> notes,
+      String expiryStr) {
+    boolean isReusable = "true".equalsIgnoreCase(notes.get(KEY_REUSABLE));
+    if (isReusable) {
+      return true;
+    }
+    long remainingTtl =
+        expiryStr != null
+            ? Math.max(1L, Long.parseLong(expiryStr) - (System.currentTimeMillis() / 1000L))
+            : 300L;
+    boolean reserved =
+        context
+            .getSession()
+            .getProvider(SingleUseObjectProvider.class)
+            .putIfAbsent(USED_KEY_PREFIX + tokenId, remainingTtl);
+    if (!reserved) {
+      log.warnf("[LT] token already used: '%s'", tokenId);
+    }
+    return reserved;
+  }
+
+  /**
+   * Sets the authenticated user on the context, applies optional email-verification / LOA /
+   * remember-me from the token notes, and calls {@code context.success()}. Assumes single-use has
+   * already been reserved via {@link #reserveSingleUse}.
+   */
+  private static void applyAuthenticatedUser(
+      AuthenticationFlowContext context, Map<String, String> notes, UserModel user) {
     context.setUser(user);
     context.getAuthenticationSession().setAuthenticatedUser(user);
     if ("true".equalsIgnoreCase(notes.get(KEY_SEV))) {
@@ -399,8 +514,7 @@ class LoginTokenHelper {
       context
           .getAuthenticationSession()
           .setUserSessionNote(
-              Constants.LOA_MAP,
-              context.getAuthenticationSession().getAuthNote(Constants.LOA_MAP));
+              Constants.LOA_MAP, context.getAuthenticationSession().getAuthNote(Constants.LOA_MAP));
     }
 
     if ("true".equalsIgnoreCase(notes.get(KEY_REMEMBER_ME))) {
@@ -414,5 +528,44 @@ class LoginTokenHelper {
         .setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, displayEmail);
     log.debugf("[LT] authentication complete for user '%s'", user.getId());
     context.success();
+  }
+
+  // -------------------------------------------------------------------------
+  // Direct-grant verification (non-interactive, no browser)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Verifies a Login Token in a non-interactive Direct Grant (Resource Owner Password Credentials)
+   * flow. Runs the same Infinispan lookup → expiry → client → user-resolution → single-use → {@code
+   * context.success()} pipeline as {@link #handleTokenId}, but deliberately omits the cookie
+   * user-switch check and never renders a browser challenge — a direct grant has no browser session
+   * to switch and cannot present forms or redirects.
+   *
+   * <p>On success {@code context.success()} has already been called and this method returns {@code
+   * null}. On failure the context is left untouched (so the caller can attach an OAuth error
+   * response) and a machine-readable result code is returned. The specific reason is logged but
+   * collapsed into a generic {@link #DG_INVALID_TOKEN} for invalid/expired/client/used tokens to
+   * avoid leaking which check failed.
+   *
+   * @return {@code null} on success, otherwise {@link #DG_INVALID_TOKEN} or {@link
+   *     #DG_USER_DISABLED}.
+   */
+  static String verifyDirectGrant(AuthenticationFlowContext context, String tokenId) {
+    ResolvedToken resolved = lookupAndValidate(context, tokenId);
+    switch (resolved.status) {
+      case INVALID:
+        return DG_INVALID_TOKEN;
+      case USER_DISABLED:
+        return DG_USER_DISABLED;
+      default:
+        break;
+    }
+
+    if (!reserveSingleUse(context, tokenId, resolved.notes, resolved.expiryStr)) {
+      return DG_INVALID_TOKEN;
+    }
+
+    applyAuthenticatedUser(context, resolved.notes, resolved.user);
+    return null;
   }
 }

--- a/src/test/java/io/phasetwo/keycloak/magic/web/LoginTokenDirectGrantTest.java
+++ b/src/test/java/io/phasetwo/keycloak/magic/web/LoginTokenDirectGrantTest.java
@@ -1,0 +1,139 @@
+package io.phasetwo.keycloak.magic.web;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import io.phasetwo.keycloak.magic.Helpers;
+import io.phasetwo.keycloak.magic.representation.LoginTokenRequest;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
+import java.util.Base64;
+import lombok.extern.jbosslog.JBossLog;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for {@link io.phasetwo.keycloak.magic.auth.LoginTokenDirectGrantAuthenticator}.
+ *
+ * <p>Drives the full Direct Grant (Resource Owner Password Credentials) path end-to-end against a
+ * real Keycloak container: a Login Token is minted via {@code POST /login-token}, then redeemed at
+ * the token endpoint with {@code grant_type=password} and the token passed as the {@code
+ * login_token} form parameter. No browser interaction and no username/password are involved.
+ */
+@JBossLog
+@org.testcontainers.junit.jupiter.Testcontainers
+public class LoginTokenDirectGrantTest extends AbstractMagicLinkTest {
+
+  private static final String TEST_REALM = "test-realm-dg";
+  private static final String TEST_CLIENT = "dg-test-client";
+  private static final String TEST_EMAIL = "testuser@phasetwo.io";
+
+  private static final String LOGIN_TOKEN_PATH = "realms/" + TEST_REALM + "/login-token";
+  private static final String TOKEN_PATH =
+      "realms/" + TEST_REALM + "/protocol/openid-connect/token";
+
+  /**
+   * Mints a Login Token via the admin API and returns the {@code login_hint} ({@code lt:{uuid}}).
+   */
+  private String createLoginToken(boolean reusable) throws Exception {
+    LoginTokenRequest request = new LoginTokenRequest();
+    request.setEmail(TEST_EMAIL);
+    request.setClientId(TEST_CLIENT);
+    request.setReusable(reusable);
+
+    return given()
+        .baseUri(getAuthUrl())
+        .auth()
+        .oauth2(keycloak.tokenManager().getAccessTokenString())
+        .contentType("application/json")
+        .body(Helpers.toJsonString(request))
+        .post(LOGIN_TOKEN_PATH)
+        .then()
+        .statusCode(200)
+        .extract()
+        .jsonPath()
+        .getString("login_hint");
+  }
+
+  private Response redeem(String loginToken) {
+    return given()
+        .baseUri(getAuthUrl())
+        .contentType("application/x-www-form-urlencoded")
+        .formParam("grant_type", "password")
+        .formParam("client_id", TEST_CLIENT)
+        .formParam("scope", "openid")
+        .formParam("login_token", loginToken)
+        .post(TOKEN_PATH);
+  }
+
+  /** Decodes the (unverified) payload of a JWT into a {@link JsonPath} for claim assertions. */
+  private static JsonPath decodeJwtPayload(String jwt) {
+    String payload = new String(Base64.getUrlDecoder().decode(jwt.split("\\.")[1]));
+    return new JsonPath(payload);
+  }
+
+  @Test
+  public void validTokenYieldsAccessTokenWithAmr() throws Exception {
+    importRealm("/realms/direct-grant-login-token-test-setup.json");
+
+    String loginHint = createLoginToken(true);
+    assertThat(loginHint, not(emptyOrNullString()));
+
+    String accessToken =
+        redeem(loginHint)
+            .then()
+            .statusCode(200)
+            .body("access_token", not(emptyOrNullString()))
+            .body("token_type", equalTo("Bearer"))
+            .extract()
+            .path("access_token");
+
+    // The access token carries amr=["login_token"] (via the execution's default.reference.value
+    // config + the oidc-amr-mapper) and acr=1 (LOA set by the authenticator).
+    JsonPath claims = decodeJwtPayload(accessToken);
+    assertThat(claims.getList("amr", String.class), hasItem("login_token"));
+    assertThat(claims.getString("acr"), equalTo("1"));
+  }
+
+  @Test
+  public void invalidTokenIsRejected() throws Exception {
+    importRealm("/realms/direct-grant-login-token-test-setup.json");
+
+    redeem("lt:00000000-0000-0000-0000-000000000000")
+        .then()
+        .statusCode(401)
+        .body("error", equalTo("invalid_grant"));
+  }
+
+  @Test
+  public void missingTokenIsRejected() throws Exception {
+    importRealm("/realms/direct-grant-login-token-test-setup.json");
+
+    given()
+        .baseUri(getAuthUrl())
+        .contentType("application/x-www-form-urlencoded")
+        .formParam("grant_type", "password")
+        .formParam("client_id", TEST_CLIENT)
+        .formParam("scope", "openid")
+        .post(TOKEN_PATH)
+        .then()
+        .statusCode(401)
+        .body("error", equalTo("invalid_request"));
+  }
+
+  @Test
+  public void singleUseTokenCannotBeRedeemedTwice() throws Exception {
+    importRealm("/realms/direct-grant-login-token-test-setup.json");
+
+    String loginHint = createLoginToken(false);
+
+    // First redemption succeeds.
+    redeem(loginHint).then().statusCode(200).body("access_token", not(emptyOrNullString()));
+
+    // Second redemption of the same single-use token is rejected.
+    redeem(loginHint).then().statusCode(401).body("error", equalTo("invalid_grant"));
+  }
+}

--- a/src/test/resources/realms/direct-grant-login-token-test-setup.json
+++ b/src/test/resources/realms/direct-grant-login-token-test-setup.json
@@ -1,0 +1,111 @@
+{
+  "realm": "test-realm-dg",
+  "displayName": "Login Token Direct Grant Test Realm",
+  "enabled": true,
+  "clientScopes": [
+    {
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "name": "amr",
+      "description": "Adding the Authentication Method Reference \"amr\" claim to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "amr",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-amr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "dg-test-client",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "redirectUris": ["http://localhost/*", "http://host.testcontainers.internal:*"],
+      "webOrigins": ["+"],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "amr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ]
+    }
+  ],
+  "authenticationFlows": [
+    {
+      "alias": "direct-grant-login-token-flow",
+      "description": "Direct grant flow that authenticates via a Login Token reference.",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "dg-login-token-ref",
+          "authenticator": "direct-grant-login-token",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "alias": "dg-login-token-ref",
+      "config": {
+        "default.reference.value": "login_token",
+        "default.reference.maxAge": "7776000"
+      }
+    }
+  ],
+  "directGrantFlow": "direct-grant-login-token-flow",
+  "users": [
+    {
+      "username": "testuser@phasetwo.io",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "testuser@phasetwo.io",
+      "firstName": "Test",
+      "lastName": "User"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a Direct Grant (Resource Owner Password Credentials) authenticator that authenticates a token request using a Login Token reference, with no browser interaction. This lets a backend exchange a previously minted Login Token (`POST /login-token`) for tokens via `POST /protocol/openid-connect/token` with `grant_type=password`, without a username/password and without going through the authorization endpoint.

### Changes

- **New `LoginTokenDirectGrantAuthenticator`** (provider id `direct-grant-login-token`), extending `AbstractDirectGrantAuthenticator`. Reads the token from the `login_token` form parameter (`lt:{uuid}` or the bare uuid) and returns standard OAuth2 errors (`401 invalid_grant` / `invalid_request`) instead of letting an `AuthenticationFlowException` surface as a `500`.
- **Refactor `LoginTokenHelper`**: extracts a shared `lookupAndValidate` pipeline (Infinispan lookup → expiry → client → user resolution) reused by both the browser (`handleTokenId`) and direct-grant (`verifyDirectGrant`) flows, plus `reserveSingleUse` / `applyAuthenticatedUser`. The expiry parse is now guarded — a malformed `expiry` note yields an invalid result rather than propagating a `NumberFormatException`.
- `amr=login_token` is produced through the execution's `default.reference.value` config and the `oidc-amr-mapper`, exactly like the browser `login-token-verifier`.

### Why

The browser `login-token-verifier` only works inside the browser flow (it reads `login_hint` from the auth-session client note, which the token endpoint never sets). Placing it in a direct grant flow ends with `context.attempted()` as the sole execution → `AuthenticationFlowException`. This authenticator is the non-interactive counterpart.

## Testing

Integration test `LoginTokenDirectGrantTest` covers: valid redemption (asserts `amr=["login_token"]` and `acr`), invalid token, missing parameter, and single-use (second redemption rejected). Verified end-to-end against Keycloak 26.6.3.
